### PR TITLE
Non-Manifold Mesh Support: NTMesh3 Enhancements

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]
 
 #endif

--- a/geometry4SharpTests/geometry4SharpTests.csproj
+++ b/geometry4SharpTests/geometry4SharpTests.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="FluentAssertions" Version="8.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.9.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/geometry4Sharp_netstandard.csproj
+++ b/geometry4Sharp_netstandard.csproj
@@ -29,6 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Folder Include="geometry4SharpTests\mesh_ops\" />
     <Folder Include="Properties\" />
     <None Include="LICENSE" Pack="true" PackagePath="LICENSE.txt" />
   </ItemGroup>

--- a/geometry4Sharp_netstandard.csproj
+++ b/geometry4Sharp_netstandard.csproj
@@ -1,22 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0.0</Version>
+    <Version>1.1.0.0</Version>
     <Title>geometry4Sharp</Title>
     <Authors></Authors>
     <Company></Company>
     <Description>C# library for 2D/3D geometric computing and triangle mesh processing forked from Geometry3Sharp</Description>
     <Copyright>Copyright © Ryan Schmidt 2016 / Copyright © TODO 2022</Copyright>
     <PackageLicenseExpression>BSL-1.0</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/NewWheelTech/geometry4Sharp</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/r-silveira/geometry4Sharp</PackageProjectUrl>
     <PackageTags>geometry3;graphics;math;approximation;solvers;color;convexhull;meshes;spatial;curves;solids;3d;unity</PackageTags>
-    <RepositoryUrl>https://github.com/NewWheelTech/geometry4Sharp</RepositoryUrl>
+    <RepositoryUrl>https://github.com/r-silveira/geometry4Sharp</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0;net48</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <RootNamespace>g4</RootNamespace>
     <AssemblyName>geometry4Sharp</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/mesh/DMesh3.cs
+++ b/mesh/DMesh3.cs
@@ -2048,7 +2048,7 @@ namespace g4
                     if (edges_refcount.isValid(i) && IsBoundaryEdge(i))
                         return false;
             }
-            return true;            
+            return true;
         }
 
         public bool CachedIsClosed {
@@ -2061,6 +2061,19 @@ namespace g4
             }
         }
 
+
+        public bool HasSelfIntersections()
+        {
+            var tree = new DMeshAABBTree3(this);
+            return tree.FindAllSelfIntersectionsTriangles().TrianglePairs.Count > 0;
+        }
+
+        public int NumberOfComponents()
+        {
+            var meshConnectedComponents = new MeshConnectedComponents(this);
+            meshConnectedComponents.FindConnectedT();
+            return meshConnectedComponents.Count;
+        }
 
 
 

--- a/mesh/MeshIterators.cs
+++ b/mesh/MeshIterators.cs
@@ -8,11 +8,26 @@ namespace g4
     public static class MeshIterators
     {
 
-        public static IEnumerable<int> FilteredVertices(DMesh3 mesh, Func<DMesh3, int, bool> FilterF )
+        public static IEnumerable<int> FilteredVertices(DMesh3 mesh, Func<DMesh3, int, bool> FilterF)
         {
             int N = mesh.MaxVertexID;
-            for ( int i = 0; i < N; ++i ) {
-                if ( mesh.IsVertex(i) ) {
+            for (int i = 0; i < N; ++i)
+            {
+                if (mesh.IsVertex(i))
+                {
+                    if (FilterF(mesh, i))
+                        yield return i;
+                }
+            }
+        }
+
+        public static IEnumerable<int> FilteredVertices(NTMesh3 mesh, Func<NTMesh3, int, bool> FilterF)
+        {
+            int N = mesh.MaxVertexID;
+            for (int i = 0; i < N; ++i)
+            {
+                if (mesh.IsVertex(i))
+                {
                     if (FilterF(mesh, i))
                         yield return i;
                 }
@@ -20,11 +35,26 @@ namespace g4
         }
 
 
-        public static IEnumerable<int> FilteredEdges(DMesh3 mesh, Func<DMesh3, int, bool> FilterF )
+        public static IEnumerable<int> FilteredEdges(DMesh3 mesh, Func<DMesh3, int, bool> FilterF)
         {
             int N = mesh.MaxEdgeID;
-            for ( int i = 0; i < N; ++i ) {
-                if ( mesh.IsEdge(i) ) {
+            for (int i = 0; i < N; ++i)
+            {
+                if (mesh.IsEdge(i))
+                {
+                    if (FilterF(mesh, i))
+                        yield return i;
+                }
+            }
+        }
+
+        public static IEnumerable<int> FilteredEdges(NTMesh3 mesh, Func<NTMesh3, int, bool> FilterF)
+        {
+            int N = mesh.MaxEdgeID;
+            for (int i = 0; i < N; ++i)
+            {
+                if (mesh.IsEdge(i))
+                {
                     if (FilterF(mesh, i))
                         yield return i;
                 }
@@ -32,11 +62,26 @@ namespace g4
         }
 
 
-        public static IEnumerable<int> FilteredTriangles(DMesh3 mesh, Func<DMesh3, int, bool> FilterF )
+        public static IEnumerable<int> FilteredTriangles(DMesh3 mesh, Func<DMesh3, int, bool> FilterF)
         {
             int N = mesh.MaxTriangleID;
-            for ( int i = 0; i < N; ++i ) {
-                if ( mesh.IsTriangle(i) ) {
+            for (int i = 0; i < N; ++i)
+            {
+                if (mesh.IsTriangle(i))
+                {
+                    if (FilterF(mesh, i))
+                        yield return i;
+                }
+            }
+        }
+
+        public static IEnumerable<int> FilteredTriangles(NTMesh3 mesh, Func<NTMesh3, int, bool> FilterF)
+        {
+            int N = mesh.MaxTriangleID;
+            for (int i = 0; i < N; ++i)
+            {
+                if (mesh.IsTriangle(i))
+                {
                     if (FilterF(mesh, i))
                         yield return i;
                 }
@@ -50,8 +95,27 @@ namespace g4
         public static IEnumerable<int> BoundaryVertices(DMesh3 mesh)
         {
             int N = mesh.MaxVertexID;
-            for ( int i = 0; i < N; ++i ) {
-                if ( mesh.IsVertex(i) ) {
+            for (int i = 0; i < N; ++i)
+            {
+                if (mesh.IsVertex(i))
+                {
+                    if (mesh.IsBoundaryVertex(i))
+                        yield return i;
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// Boundary vertices of mesh
+        /// </summary>
+        public static IEnumerable<int> BoundaryVertices(NTMesh3 mesh)
+        {
+            int N = mesh.MaxVertexID;
+            for (int i = 0; i < N; ++i)
+            {
+                if (mesh.IsVertex(i))
+                {
                     if (mesh.IsBoundaryVertex(i))
                         yield return i;
                 }
@@ -65,8 +129,27 @@ namespace g4
         public static IEnumerable<int> BoundaryEdgeVertices(DMesh3 mesh)
         {
             int N = mesh.MaxEdgeID;
-            for (int i = 0; i < N; ++i) {
-                if (mesh.IsEdge(i) && mesh.IsBoundaryEdge(i)) {
+            for (int i = 0; i < N; ++i)
+            {
+                if (mesh.IsEdge(i) && mesh.IsBoundaryEdge(i))
+                {
+                    Index2i ev = mesh.GetEdgeV(i);
+                    yield return ev.a;
+                    yield return ev.b;
+                }
+            }
+        }
+
+        /// <summary>
+        /// boundary vertices of mesh, but based on edges, so returns each vertex twice!
+        /// </summary>
+        public static IEnumerable<int> BoundaryEdgeVertices(NTMesh3 mesh)
+        {
+            int N = mesh.MaxEdgeID;
+            for (int i = 0; i < N; ++i)
+            {
+                if (mesh.IsEdge(i) && mesh.IsBoundaryEdge(i))
+                {
                     Index2i ev = mesh.GetEdgeV(i);
                     yield return ev.a;
                     yield return ev.b;
@@ -78,8 +161,24 @@ namespace g4
         public static IEnumerable<int> InteriorVertices(DMesh3 mesh)
         {
             int N = mesh.MaxVertexID;
-            for ( int i = 0; i < N; ++i ) {
-                if ( mesh.IsVertex(i) ) {
+            for (int i = 0; i < N; ++i)
+            {
+                if (mesh.IsVertex(i))
+                {
+                    if (mesh.IsBoundaryVertex(i) == false)
+                        yield return i;
+                }
+            }
+        }
+
+
+        public static IEnumerable<int> InteriorVertices(NTMesh3 mesh)
+        {
+            int N = mesh.MaxVertexID;
+            for (int i = 0; i < N; ++i)
+            {
+                if (mesh.IsVertex(i))
+                {
                     if (mesh.IsBoundaryVertex(i) == false)
                         yield return i;
                 }
@@ -91,8 +190,10 @@ namespace g4
         public static IEnumerable<int> GroupBoundaryVertices(DMesh3 mesh)
         {
             int N = mesh.MaxVertexID;
-            for ( int i = 0; i < N; ++i ) {
-                if ( mesh.IsVertex(i) ) {
+            for (int i = 0; i < N; ++i)
+            {
+                if (mesh.IsVertex(i))
+                {
                     if (mesh.IsGroupBoundaryVertex(i))
                         yield return i;
                 }
@@ -100,23 +201,63 @@ namespace g4
         }
 
 
+        //public static IEnumerable<int> GroupBoundaryVertices(NTMesh3 mesh)
+        //{
+        //    int N = mesh.MaxVertexID;
+        //    for ( int i = 0; i < N; ++i ) {
+        //        if ( mesh.IsVertex(i) ) {
+        //            if (mesh.IsGroupBoundaryVertex(i))
+        //                yield return i;
+        //        }
+        //    }
+        //}
+
+
         public static IEnumerable<int> GroupJunctionVertices(DMesh3 mesh)
         {
             int N = mesh.MaxVertexID;
-            for ( int i = 0; i < N; ++i ) {
-                if ( mesh.IsVertex(i) ) {
+            for (int i = 0; i < N; ++i)
+            {
+                if (mesh.IsVertex(i))
+                {
                     if (mesh.IsGroupJunctionVertex(i))
                         yield return i;
                 }
             }
         }
 
+        //public static IEnumerable<int> GroupJunctionVertices(NTMesh3 mesh)
+        //{
+        //    int N = mesh.MaxVertexID;
+        //    for ( int i = 0; i < N; ++i ) {
+        //        if ( mesh.IsVertex(i) ) {
+        //            if (mesh.IsGroupJunctionVertex(i))
+        //                yield return i;
+        //        }
+        //    }
+        //}
+
 
         public static IEnumerable<int> BoundaryEdges(DMesh3 mesh)
         {
             int N = mesh.MaxEdgeID;
-            for ( int i = 0; i < N; ++i ) {
-                if ( mesh.IsEdge(i) ) {
+            for (int i = 0; i < N; ++i)
+            {
+                if (mesh.IsEdge(i))
+                {
+                    if (mesh.IsBoundaryEdge(i))
+                        yield return i;
+                }
+            }
+        }
+
+        public static IEnumerable<int> BoundaryEdges(NTMesh3 mesh)
+        {
+            int N = mesh.MaxEdgeID;
+            for (int i = 0; i < N; ++i)
+            {
+                if (mesh.IsEdge(i))
+                {
                     if (mesh.IsBoundaryEdge(i))
                         yield return i;
                 }
@@ -124,23 +265,41 @@ namespace g4
         }
 
 
-		public static IEnumerable<int> InteriorEdges(DMesh3 mesh)
-		{
-			int N = mesh.MaxEdgeID;
-			for (int i = 0; i < N; ++i) {
-				if (mesh.IsEdge(i)) {
-					if (mesh.IsBoundaryEdge(i) == false)
-						yield return i;
-				}
-			}
-		}
+        public static IEnumerable<int> InteriorEdges(DMesh3 mesh)
+        {
+            int N = mesh.MaxEdgeID;
+            for (int i = 0; i < N; ++i)
+            {
+                if (mesh.IsEdge(i))
+                {
+                    if (mesh.IsBoundaryEdge(i) == false)
+                        yield return i;
+                }
+            }
+        }
+
+
+        public static IEnumerable<int> InteriorEdges(NTMesh3 mesh)
+        {
+            int N = mesh.MaxEdgeID;
+            for (int i = 0; i < N; ++i)
+            {
+                if (mesh.IsEdge(i))
+                {
+                    if (mesh.IsBoundaryEdge(i) == false)
+                        yield return i;
+                }
+            }
+        }
 
 
         public static IEnumerable<int> GroupBoundaryEdges(DMesh3 mesh)
         {
             int N = mesh.MaxEdgeID;
-            for ( int i = 0; i < N; ++i ) {
-                if ( mesh.IsEdge(i) ) {
+            for (int i = 0; i < N; ++i)
+            {
+                if (mesh.IsEdge(i))
+                {
                     if (mesh.IsGroupBoundaryEdge(i))
                         yield return i;
                 }
@@ -148,13 +307,27 @@ namespace g4
         }
 
 
-
-
         public static IEnumerable<int> BowtieVertices(DMesh3 mesh)
         {
             int N = mesh.MaxVertexID;
-            for ( int i = 0; i < N; ++i ) {
-                if ( mesh.IsVertex(i) ) {
+            for (int i = 0; i < N; ++i)
+            {
+                if (mesh.IsVertex(i))
+                {
+                    if (mesh.IsBowtieVertex(i))
+                        yield return i;
+                }
+            }
+        }
+
+
+        public static IEnumerable<int> BowtieVertices(NTMesh3 mesh)
+        {
+            int N = mesh.MaxVertexID;
+            for (int i = 0; i < N; ++i)
+            {
+                if (mesh.IsVertex(i))
+                {
                     if (mesh.IsBowtieVertex(i))
                         yield return i;
                 }

--- a/mesh/MeshNormals.cs
+++ b/mesh/MeshNormals.cs
@@ -59,6 +59,20 @@ namespace g4
             }
         }
 
+        public void CopyTo(NTMesh3 SetMesh)
+        {
+            if (SetMesh.MaxVertexID < Mesh.MaxVertexID)
+                throw new Exception("MeshNormals.Set: SetMesh does not have enough vertices!");
+            if (!SetMesh.HasVertexNormals)
+                SetMesh.EnableVertexNormals(Vector3f.AxisY);
+            int NV = Mesh.MaxVertexID;
+            for ( int vi = 0; vi < NV; ++vi ) {
+                if ( Mesh.IsVertex(vi) && SetMesh.IsVertex(vi) ) {
+                    SetMesh.SetVertexNormal(vi, (Vector3f)Normals[vi]);
+                }
+            }
+        }
+
 
 
 
@@ -106,8 +120,25 @@ namespace g4
             normals.CopyTo(mesh);
         }
 
+        public static void QuickCompute(NTMesh3 mesh)
+        {
+            MeshNormals normals = new MeshNormals(mesh);
+            normals.Compute();
+            normals.CopyTo(mesh);
+        }
 
         public static Vector3d QuickCompute(DMesh3 mesh, int vid, NormalsTypes type = NormalsTypes.Vertex_OneRingFaceAverage_AreaWeighted)
+        {
+            Vector3d sum = Vector3d.Zero;
+            Vector3d n, c; double a;
+            foreach ( int tid in mesh.VtxTrianglesItr(vid)) {
+                mesh.GetTriInfo(tid, out n, out a, out c);
+                sum += a * n;
+            }
+            return sum.Normalized;
+        }
+
+        public static Vector3d QuickCompute(NTMesh3 mesh, int vid, NormalsTypes type = NormalsTypes.Vertex_OneRingFaceAverage_AreaWeighted)
         {
             Vector3d sum = Vector3d.Zero;
             Vector3d n, c; double a;

--- a/mesh/NTEdgeLoop.cs
+++ b/mesh/NTEdgeLoop.cs
@@ -1,0 +1,400 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+
+namespace g4
+{
+    /// <summary>
+    /// Sequential set of vertices/edges in a mesh, that form a closed loop.
+    /// 
+    /// If all you have are the vertices, use EdgeLoop.VertexLoopToEdgeLoop() to construct an EdgeLoop
+    /// </summary>
+    public class NTEdgeLoop
+    {
+        public NTMesh3 Mesh;
+
+        public int[] Vertices;
+        public int[] Edges;
+
+        public int[] BowtieVertices;        // this may not be initialized!
+
+
+        public NTEdgeLoop(NTMesh3 mesh)
+        {
+            Mesh = mesh;
+        }
+        public NTEdgeLoop(NTMesh3 mesh, int[] vertices, int[] edges, bool bCopyArrays)
+        {
+            Mesh = mesh;
+            if ( bCopyArrays ) {
+                Vertices = new int[vertices.Length];
+                Array.Copy(vertices, Vertices, Vertices.Length);
+                Edges = new int[edges.Length];
+                Array.Copy(edges, Edges, Edges.Length);
+            } else {
+                Vertices = vertices;
+                Edges = edges;
+            }
+        }
+
+        public NTEdgeLoop(NTEdgeLoop copy)
+        {
+            Mesh = copy.Mesh;
+            Vertices = new int[copy.Vertices.Length];
+            Array.Copy(copy.Vertices, Vertices, Vertices.Length);
+            Edges = new int[copy.Edges.Length];
+            Array.Copy(copy.Edges, Edges, Edges.Length);
+            if (copy.BowtieVertices != null) {
+                BowtieVertices = new int[copy.BowtieVertices.Length];
+                Array.Copy(copy.BowtieVertices, BowtieVertices, BowtieVertices.Length);
+            }
+        }
+
+
+        /// <summary>
+        /// construct EdgeLoop from a list of edges of mesh
+        /// </summary>
+        public static NTEdgeLoop FromEdges(NTMesh3 mesh, IList<int> edges)
+        {
+            int[] Edges = new int[edges.Count];
+            for (int i = 0; i < Edges.Length; ++i)
+                Edges[i] = edges[i];
+
+            int[] Vertices = new int[Edges.Length];
+            Index2i start_ev = mesh.GetEdgeV(Edges[0]);
+            Index2i prev_ev = start_ev;
+            for (int i = 1; i < Edges.Length; ++i) {
+                Index2i next_ev = mesh.GetEdgeV(Edges[i % Edges.Length]);
+                Vertices[i] = IndexUtil.find_shared_edge_v(ref prev_ev, ref next_ev);
+                prev_ev = next_ev;
+            }
+            Vertices[0] = IndexUtil.find_edge_other_v(ref start_ev, Vertices[1]);
+            return new NTEdgeLoop(mesh, Vertices, Edges, false);
+        }
+
+
+        /// <summary>
+        /// construct EdgeLoop from a list of vertices of mesh
+        /// </summary>
+        public static NTEdgeLoop FromVertices(NTMesh3 mesh, IList<int> vertices)
+        {
+            int NV = vertices.Count;
+            int[] Vertices = new int[NV];
+            for (int i = 0; i < NV; ++i)
+                Vertices[i] = vertices[i];
+            int NE = NV;
+            int[] Edges = new int[NE];
+            for (int i = 0; i < NE; ++i) {
+                Edges[i] = mesh.FindEdge(Vertices[i], Vertices[(i + 1)%NE]);
+                if (Edges[i] == DMesh3.InvalidID)
+                    throw new Exception("EdgeLoop.FromVertices: vertices are not connected by edge!");
+            }
+            return new NTEdgeLoop(mesh, Vertices, Edges, false);
+        }
+
+
+
+        /// <summary>
+        /// construct EdgeLoop from a list of vertices of mesh
+        /// if loop is a boundary edge, we can correct orientation if requested
+        /// </summary>
+        public static NTEdgeLoop FromVertices(NTMesh3 mesh, IList<int> vertices, bool bAutoOrient = true)
+        {
+            int[] Vertices = new int[vertices.Count];
+            for (int i = 0; i < Vertices.Length; i++) 
+                Vertices[i] = vertices[i];
+
+            if ( bAutoOrient ) {
+                int a = Vertices[0], b = Vertices[1];
+                int eid = mesh.FindEdge(a, b);
+                if (mesh.IsBoundaryEdge(eid)) {
+                    Index2i ev = mesh.GetOrientedBoundaryEdgeV(eid);
+                    if (ev.a == b && ev.b == a)
+                        Array.Reverse(Vertices);
+                }
+            }
+
+            int[] Edges = new int[Vertices.Length];
+            for (int i = 0; i < Edges.Length; ++i) {
+                int a = Vertices[i], b = Vertices[(i + 1) % Vertices.Length];
+                Edges[i] = mesh.FindEdge(a, b);
+                if (Edges[i] == DMesh3.InvalidID)
+                    throw new Exception("EdgeLoop.FromVertices: invalid edge [" + a + "," + b + "]");
+            }
+
+            return new NTEdgeLoop(mesh, Vertices, Edges, false);
+        }
+
+
+        public int VertexCount {
+            get { return Vertices.Length; }
+        }
+        public int EdgeCount {
+            get { return Edges.Length; }
+        }
+
+        public Vector3d GetVertex(int i) {
+            return Mesh.GetVertex(Vertices[i]);
+        }
+
+
+        public AxisAlignedBox3d GetBounds()
+        {
+            AxisAlignedBox3d box = AxisAlignedBox3d.Empty;
+            for (int i = 0; i < Vertices.Length; ++i)
+                box.Contain(Mesh.GetVertex(Vertices[i]));
+            return box;
+        }
+
+
+        //public DCurve3 ToCurve(DMesh3 sourceMesh = null)
+        //{
+        //    if (sourceMesh == null)
+        //        sourceMesh = Mesh;
+        //    DCurve3 curve = MeshUtil.ExtractLoopV(sourceMesh, Vertices);
+        //    curve.Closed = true;
+        //    return curve;
+        //}
+
+
+        /// <summary>
+        /// if this is a border edge-loop, we can check that it is oriented correctly, and
+        /// if not, reverse it.
+        /// Returns true if we reversed orientation.
+        /// </summary>
+        public bool CorrectOrientation()
+        {
+            int a = Vertices[0], b = Vertices[1];
+            int eid = Mesh.FindEdge(a, b);
+            if (Mesh.IsBoundaryEdge(eid)) {
+                Index2i ev = Mesh.GetOrientedBoundaryEdgeV(eid);
+                if (ev.a == b && ev.b == a) {
+                    Reverse();
+                    return true;
+                }
+            }
+            return false;
+        }
+
+
+        public void Reverse()
+        {
+            Array.Reverse(Vertices);
+            Array.Reverse(Edges);
+        }
+
+
+        /// <summary>
+        /// check if all edges of this loop are internal edges (ie none on boundary)
+        /// </summary>
+        /// <returns></returns>
+        public bool IsInternalLoop()
+        {
+            int NV = Vertices.Length;
+            for (int i = 0; i < NV; ++i ) {
+                int eid = Mesh.FindEdge(Vertices[i], Vertices[(i + 1) % NV]);
+                Debug.Assert(eid != DMesh3.InvalidID);
+                if (Mesh.IsBoundaryEdge(eid))
+                    return false;
+            }
+            return true;
+        }
+
+
+        /// <summary>
+        /// Check if all edges of this loop are boundary edges.
+        /// If testMesh != null, will check that mesh instead of internal Mesh
+        /// </summary>
+        public bool IsBoundaryLoop(NTMesh3 testMesh = null)
+        {
+            var useMesh = (testMesh != null) ? testMesh : Mesh;
+
+            int NV = Vertices.Length;
+            for (int i = 0; i < NV; ++i ) {
+                int eid = useMesh.FindEdge(Vertices[i], Vertices[(i + 1) % NV]);
+                Debug.Assert(eid != DMesh3.InvalidID);
+                if (useMesh.IsBoundaryEdge(eid) == false)
+                    return false;
+            }
+            return true;
+        }
+
+
+        /// <summary>
+        /// find index of vertex vID in Vertices list, or -1 if not found
+        /// </summary>
+        public int FindVertexIndex(int vID)
+        {
+            int N = Vertices.Length;
+            for (int i = 0; i < N; ++i) {
+                if (Vertices[i] == vID)
+                    return i;
+            }
+            return -1;
+        }
+
+        /// <summary>
+        /// find index of vertices of loop that is closest to point v
+        /// </summary>
+        public int FindNearestVertex(Vector3d v)
+        {
+            int iNear = -1;
+            double fNearSqr = double.MaxValue;
+            int N = Vertices.Length;
+            for ( int i = 0; i < N; ++i ) {
+                Vector3d lv = Mesh.GetVertex(Vertices[i]);
+                double d2 = v.DistanceSquared(lv);
+                if ( d2 < fNearSqr ) {
+                    fNearSqr = d2;
+                    iNear = i;
+                }
+            }
+            return iNear;
+        }
+
+        // count # of vertices in loop that are within tol of v
+        // final param returns last encountered index within tolerance, or -1 if return is 0
+        public int CountWithinTolerance(Vector3d v, double tol, out int last_in_tol)
+        {
+            last_in_tol = -1;
+            int count = 0;
+            int N = Vertices.Length;
+            for (int i = 0; i < N; ++i) {
+                Vector3d lv = Mesh.GetVertex(Vertices[i]);
+                if (v.Distance(lv) < tol) {
+                    count++;
+                    last_in_tol = i;
+                }
+            }
+            return count;
+        }
+
+
+        // Check if Loop2 is the same set of positions on another mesh.
+        // Does not require the indexing to be the same
+        // Currently doesn't handle loop-reversal
+        public bool IsSameLoop(EdgeLoop Loop2, bool bReverse2 = false, double tolerance = MathUtil.ZeroTolerance)
+        {
+            // find a duplicate starting vertex
+            int N = Vertices.Length;
+            int N2 = Loop2.Vertices.Length;
+            if (N != N2)
+                return false;
+
+            DMesh3 Mesh2 = Loop2.Mesh;
+
+            int start_i = 0, start_j = -1;
+
+            // try to find a unique same-vertex on each loop. Do not
+            // use vertices that have duplicate positions.
+            bool bFoundGoodStart = false;
+            while ( !bFoundGoodStart && start_i < N ) {
+                Vector3d start_v = Mesh.GetVertex(start_i);
+                int count = Loop2.CountWithinTolerance(start_v, tolerance, out start_j);
+                if (count == 1)
+                    bFoundGoodStart = true;
+                else
+                    start_i++;
+            }
+            if (!bFoundGoodStart)
+                return false;       // no within-tolerance duplicate vtx to start at
+
+            for ( int ii = 0; ii < N; ++ii ) {
+                int i = (start_i + ii) % N;
+                int j = (bReverse2) ? 
+                    MathUtil.WrapSignedIndex(start_j - ii, N2)
+                    : (start_j + ii) % N2;
+                Vector3d v = Mesh.GetVertex(Vertices[i]);
+                Vector3d v2 = Mesh2.GetVertex(Loop2.Vertices[j]);
+                if (v.Distance(v2) > tolerance)
+                    return false;
+            }
+
+            return true;
+        }
+
+
+
+        /// <summary>
+        /// stores vertices [starti, starti+1, ... starti+count-1] in span, and returns span, or null if invalid range
+        /// </summary>
+        public int[] GetVertexSpan(int starti, int count, int[] span, bool reverse = false)
+        {
+            int N = Vertices.Length;
+            if (starti < 0 || starti >= N || count > N - 1)
+                return null;
+            if (reverse) {
+                for (int k = 0; k < count; ++k)
+                    span[count-k-1] = Vertices[(starti + k) % N];
+            } else {
+                for (int k = 0; k < count; ++k)
+                    span[k] = Vertices[(starti + k) % N];
+            }
+            return span;
+        }
+
+
+
+
+        /// <summary>
+        /// Exhaustively check that verts and edges of this EdgeLoop are consistent. Not for production use.
+        /// </summary>
+        public bool CheckValidity(FailMode eFailMode = FailMode.Throw)
+        {
+            bool is_ok = true;
+            Action<bool> CheckOrFailF = (b) => { is_ok = is_ok && b; };
+            if (eFailMode == FailMode.DebugAssert) {
+                CheckOrFailF = (b) => { Debug.Assert(b); is_ok = is_ok && b; };
+            } else if (eFailMode == FailMode.gDevAssert) {
+                CheckOrFailF = (b) => { Util.gDevAssert(b); is_ok = is_ok && b; };
+            } else if (eFailMode == FailMode.Throw) {
+                CheckOrFailF = (b) => { if (b == false) throw new Exception("EdgeLoop.CheckValidity: check failed"); };
+            }
+
+            CheckOrFailF(Vertices.Length == Edges.Length);
+            for (int ei = 0; ei < Edges.Length; ++ei) {
+                Index2i ev = Mesh.GetEdgeV(Edges[ei]);
+                CheckOrFailF(Mesh.IsVertex(ev.a));
+                CheckOrFailF(Mesh.IsVertex(ev.b));
+                CheckOrFailF(Mesh.FindEdge(ev.a, ev.b) != DMesh3.InvalidID);
+                CheckOrFailF(Vertices[ei] == ev.a || Vertices[ei] == ev.b);
+                CheckOrFailF(Vertices[(ei + 1) % Edges.Length] == ev.a || Vertices[(ei + 1) % Edges.Length] == ev.b);
+            }
+            for ( int vi = 0; vi < Vertices.Length; ++vi ) {
+                int a = Vertices[vi], b = Vertices[(vi + 1) % Vertices.Length];
+                CheckOrFailF(Mesh.IsVertex(a));
+                CheckOrFailF(Mesh.IsVertex(b));
+                CheckOrFailF(Mesh.FindEdge(a,b) != DMesh3.InvalidID);
+                int n = 0, edge_before_b = Edges[vi], edge_after_b = Edges[(vi + 1) % Vertices.Length];
+                foreach ( int nbr_e in Mesh.VtxEdgesItr(b) ) {
+                    if (nbr_e == edge_before_b || nbr_e == edge_after_b)
+                        n++;
+                }
+                CheckOrFailF(n == 2);
+            }
+            return is_ok;
+        }
+
+
+
+
+        /// <summary>
+        /// Convert a vertex loop to an edge loop. This should be somewhere else...
+        /// </summary>
+        public static int[] VertexLoopToEdgeLoop(NTMesh3 mesh, int[] vertex_loop)
+        {
+            int NV = vertex_loop.Length;
+            int[] edges = new int[NV];
+            for ( int i = 0; i < NV; ++i ) {
+                int v0 = vertex_loop[i];
+                int v1 = vertex_loop[(i + 1) % NV];
+                edges[i] = mesh.FindEdge(v0, v1);
+            }
+            return edges;
+        }
+
+
+
+    }
+}

--- a/mesh/NTEdgeSpan.cs
+++ b/mesh/NTEdgeSpan.cs
@@ -1,0 +1,254 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace g4
+{
+	/// <summary>
+	/// An EdgeSpan is a continous set of edges in a Mesh that is *not* closed
+	/// (that would be an EdgeLoop)
+	/// </summary>
+    public class NTEdgeSpan
+    {
+        public NTMesh3 Mesh;
+
+        public int[] Vertices;
+        public int[] Edges;
+
+        public int[] BowtieVertices;        // this may not be initialized!
+
+
+        public NTEdgeSpan(NTMesh3 mesh)
+        {
+            Mesh = mesh;
+        }
+
+        public NTEdgeSpan(NTMesh3 mesh, int[] vertices, int[] edges, bool bCopyArrays)
+        {
+            Mesh = mesh;
+            if (bCopyArrays) {
+                Vertices = new int[vertices.Length];
+                Array.Copy(vertices, Vertices, Vertices.Length);
+                Edges = new int[edges.Length];
+                Array.Copy(edges, Edges, Edges.Length);
+            } else {
+                Vertices = vertices;
+                Edges = edges;
+            }
+        }
+
+        /// <summary>
+        /// construct EdgeSpan from a list of edges of mesh
+        /// </summary>
+        public static NTEdgeSpan FromEdges(NTMesh3 mesh, IList<int> edges)
+        {
+            int[] Edges = new int[edges.Count];
+            for (int i = 0; i < Edges.Length; ++i)
+                Edges[i] = edges[i];
+            int[] Vertices = new int[Edges.Length+1];
+            Index2i start_ev = mesh.GetEdgeV(Edges[0]);
+            Index2i prev_ev = start_ev;
+            if (Edges.Length > 1) {
+                for (int i = 1; i < Edges.Length; ++i) {
+                    Index2i next_ev = mesh.GetEdgeV(Edges[i]);
+                    Vertices[i] = IndexUtil.find_shared_edge_v(ref prev_ev, ref next_ev);
+                    prev_ev = next_ev;
+                }
+                Vertices[0] = IndexUtil.find_edge_other_v(ref start_ev, Vertices[1]);
+                Vertices[Vertices.Length - 1] = IndexUtil.find_edge_other_v(prev_ev, Vertices[Vertices.Length - 2]);
+            } else {
+                Vertices[0] = start_ev[0]; Vertices[1] = start_ev[1];
+            }
+            return new NTEdgeSpan(mesh, Vertices, Edges, false);
+        }
+
+
+        /// <summary>
+        /// construct EdgeSpan from a list of vertices of mesh
+        /// </summary>
+        public static NTEdgeSpan FromVertices(NTMesh3 mesh, IList<int> vertices)
+        {
+            int NV = vertices.Count;
+            int[] Vertices = new int[NV];
+            for (int i = 0; i < NV; ++i)
+                Vertices[i] = vertices[i];
+            int NE = NV - 1;
+            int[] Edges = new int[NE];
+            for ( int i = 0; i < NE; ++i ) {
+                Edges[i] = mesh.FindEdge(Vertices[i], Vertices[i + 1]);
+                if (Edges[i] == DMesh3.InvalidID)
+                    throw new Exception("EdgeSpan.FromVertices: vertices are not connected by edge!");
+            }
+            return new NTEdgeSpan(mesh, Vertices, Edges, false);
+        }
+
+
+
+        public int VertexCount {
+            get { return Vertices.Length; }
+        }
+        public int EdgeCount {
+            get { return Edges.Length; }
+        }
+
+        public Vector3d GetVertex(int i) {
+            return Mesh.GetVertex(Vertices[i]);
+        }
+
+
+        public AxisAlignedBox3d GetBounds()
+        {
+            AxisAlignedBox3d box = AxisAlignedBox3d.Empty;
+            for (int i = 0; i < Vertices.Length; ++i)
+                box.Contain(Mesh.GetVertex(Vertices[i]));
+            return box;
+        }
+
+
+        //public DCurve3 ToCurve(DMesh3 sourceMesh = null)
+        //{
+        //    if (sourceMesh == null)
+        //        sourceMesh = Mesh;
+        //    DCurve3 curve = MeshUtil.ExtractLoopV(sourceMesh, Vertices);
+        //    curve.Closed = false;
+        //    return curve;
+        //}
+
+
+        public bool IsInternalSpan()
+        {
+            int NV = Vertices.Length;
+            for (int i = 0; i < NV-1; ++i ) {
+                int eid = Mesh.FindEdge(Vertices[i], Vertices[i + 1]);
+                Debug.Assert(eid != DMesh3.InvalidID);
+                if (Mesh.IsBoundaryEdge(eid))
+                    return false;
+            }
+            return true;
+        }
+
+
+        public bool IsBoundarySpan(NTMesh3 testMesh = null)
+        {
+            var useMesh = (testMesh != null) ? testMesh : Mesh;
+
+            int NV = Vertices.Length;
+            for (int i = 0; i < NV-1; ++i ) {
+                int eid = useMesh.FindEdge(Vertices[i], Vertices[i + 1]);
+                Debug.Assert(eid != DMesh3.InvalidID);
+                if (useMesh.IsBoundaryEdge(eid) == false)
+                    return false;
+            }
+            return true;
+        }
+
+
+        public int FindNearestVertex(Vector3d v)
+        {
+            int iNear = -1;
+            double fNearSqr = double.MaxValue;
+            int N = Vertices.Length;
+            for ( int i = 0; i < N; ++i ) {
+                Vector3d lv = Mesh.GetVertex(Vertices[i]);
+                double d2 = v.DistanceSquared(lv);
+                if ( d2 < fNearSqr ) {
+                    fNearSqr = d2;
+                    iNear = i;
+                }
+            }
+            return iNear;
+        }
+
+        // count # of vertices in loop that are within tol of v
+        // final param returns last encountered index within tolerance, or -1 if return is 0
+        public int CountWithinTolerance(Vector3d v, double tol, out int last_in_tol)
+        {
+            last_in_tol = -1;
+            int count = 0;
+            int N = Vertices.Length;
+            for (int i = 0; i < N; ++i) {
+                Vector3d lv = Mesh.GetVertex(Vertices[i]);
+                if (v.Distance(lv) < tol) {
+                    count++;
+                    last_in_tol = i;
+                }
+            }
+            return count;
+        }
+
+
+        // Check if Spanw is the same set of positions on another mesh.
+        // Does not require the indexing to be the same
+        public bool IsSameSpan(EdgeSpan Spanw, bool bReverse2 = false, double tolerance = MathUtil.ZeroTolerance)
+        {
+			// [RMS] this is much easier than for a loop, because it has to have 
+			//   same endpoints. But don't have time right now.
+			throw new NotImplementedException("todo!");
+        }
+
+
+
+        /// <summary>
+        /// Exhaustively check that verts and edges of this EdgeSpan are consistent. Not for production use.
+        /// </summary>
+        public bool CheckValidity(FailMode eFailMode = FailMode.Throw)
+        {
+            bool is_ok = true;
+            Action<bool> CheckOrFailF = (b) => { is_ok = is_ok && b; };
+            if (eFailMode == FailMode.DebugAssert) {
+                CheckOrFailF = (b) => { Debug.Assert(b); is_ok = is_ok && b; };
+            } else if (eFailMode == FailMode.gDevAssert) {
+                CheckOrFailF = (b) => { Util.gDevAssert(b); is_ok = is_ok && b; };
+            } else if (eFailMode == FailMode.Throw) {
+                CheckOrFailF = (b) => { if (b == false) throw new Exception("EdgeSpan.CheckValidity: check failed"); };
+            }
+
+            CheckOrFailF(Vertices.Length == Edges.Length + 1);
+            for (int ei = 0; ei < Edges.Length; ++ei) {
+                Index2i ev = Mesh.GetEdgeV(Edges[ei]);
+                CheckOrFailF(Mesh.IsVertex(ev.a));
+                CheckOrFailF(Mesh.IsVertex(ev.b));
+                CheckOrFailF(Mesh.FindEdge(ev.a, ev.b) != DMesh3.InvalidID);
+                CheckOrFailF(Vertices[ei] == ev.a || Vertices[ei] == ev.b);
+                CheckOrFailF(Vertices[ei + 1] == ev.a || Vertices[ei + 1] == ev.b);
+            }
+            for (int vi = 0; vi < Vertices.Length-1; ++vi) {
+                int a = Vertices[vi], b = Vertices[vi + 1];
+                CheckOrFailF(Mesh.IsVertex(a));
+                CheckOrFailF(Mesh.IsVertex(b));
+                CheckOrFailF(Mesh.FindEdge(a, b) != DMesh3.InvalidID);
+                if (vi < Vertices.Length - 2) {
+                    int n = 0, edge_before_b = Edges[vi], edge_after_b = Edges[vi + 1];
+                    foreach (int nbr_e in Mesh.VtxEdgesItr(b)) {
+                        if (nbr_e == edge_before_b || nbr_e == edge_after_b)
+                            n++;
+                    }
+                    CheckOrFailF(n == 2);
+                }
+            }
+            return true;
+        }
+
+
+
+
+
+        /// <summary>
+        /// Convert vertex span to list of edges. This should be somewhere else.
+        /// </summary>
+        public static int[] VerticesToEdges(NTMesh3 mesh, int[] vertex_span)
+        {
+            int NV = vertex_span.Length;
+            int[] edges = new int[NV-1];
+            for ( int i = 0; i < NV-1; ++i ) {
+                int v0 = vertex_span[i];
+                int v1 = vertex_span[(i + 1)];
+                edges[i] = mesh.FindEdge(v0, v1);
+            }
+            return edges;
+        }
+
+
+
+    }
+}

--- a/mesh/NTMesh3.cs
+++ b/mesh/NTMesh3.cs
@@ -487,11 +487,12 @@ namespace g4
         public Index2i GetOrientedBoundaryEdgeV(int eID)
         {
             if ( edges_refcount.isValid(eID) && edge_is_boundary(eID) ) {
-                int ei = 2 * eID;
-                int a = edges[ei], b = edges[ei + 1];
+                var eIndices = GetEdgeV(eID);
+                int a = eIndices.a, b = eIndices.b;
 
                 int ti = edge_triangles.First(eID);
-                Index3i tri = new Index3i(triangles[ti], triangles[ti + 1], triangles[ti + 2]);
+                //Index3i tri = new Index3i(triangles[ti], triangles[ti + 1], triangles[ti + 2]);
+                var tri = GetTriangle(ti);
                 int ai = IndexUtil.find_edge_index_in_tri(a, b, ref tri);
                 return new Index2i(tri[ai], tri[(ai + 1) % 3]);
             }
@@ -966,7 +967,7 @@ namespace g4
         protected bool edge_has_t(int eid, int tid) {
             return edge_triangles.Contains(eid, tid);
         }
-        protected int edge_other_v(int eID, int vID)
+        public int edge_other_v(int eID, int vID)
         {
 			int i = 2*eID;
             int ev0 = edges[i], ev1 = edges[i + 1];
@@ -1033,6 +1034,26 @@ namespace g4
             return InvalidID;
         }
 
+        /// <summary>
+        /// Find triangle made up of any permutation of vertices [a,b,c]
+        /// </summary>
+        public int FindTriangle(int a, int b, int c)
+        {
+            int eid = find_edge(a, b);
+            if (eid == InvalidID)
+                return InvalidID;
+
+            foreach (var tid in EdgeTrianglesItr(eid))
+            {
+                var triVertices = GetTriangle(tid);
+                if (triVertices.a == c || triVertices.b == c || triVertices.c == c)
+                {
+                    return tid;
+                }
+            }
+
+            return InvalidID;
+        }
 
 
         /// <summary>

--- a/mesh/NTMesh3.cs
+++ b/mesh/NTMesh3.cs
@@ -508,6 +508,15 @@ namespace g4
                 v = v, bHaveC = false, bHaveUV = false, bHaveN = false
             });
         }
+
+        /// <summary>
+        /// copy vertex fromVID from existing source mesh, returns new vid
+        /// </summary>
+        public int AppendVertex(NTMesh3 from, int fromVID)
+        {
+            return AppendVertex(from.GetVertex(fromVID));
+        }
+
         public int AppendVertex(NewVertexInfo info)
         {
             int vid = vertices_refcount.allocate();

--- a/mesh/NTMesh3.cs
+++ b/mesh/NTMesh3.cs
@@ -802,7 +802,23 @@ namespace g4
         /// <summary>
         /// Returns count of boundary edges at vertex
         /// </summary>
-        public int VtxBoundaryEdges(int vID)
+        public List<int> VtxBoundaryEdges(int vID)
+        {
+            if ( vertices_refcount.isValid(vID) ) {
+                var result = new List<int>();
+                foreach (int eid in vertex_edges.ValueItr(vID)) {
+                    if (edge_triangles.Count(eid) == 1)
+                        result.Add(eid);
+                }
+                return result;
+            }
+            return new List<int>();
+        }
+
+        /// <summary>
+        /// Returns count of boundary edges at vertex
+        /// </summary>
+        public int CountVtxBoundaryEdges(int vID)
         {
             if ( vertices_refcount.isValid(vID) ) {
                 int count = 0;

--- a/mesh/NTMesh3.cs
+++ b/mesh/NTMesh3.cs
@@ -791,7 +791,6 @@ namespace g4
             if (!IsVertex(vID))
                 return MeshResult.Failed_NotAVertex;
 
-            vTriangles.Clear();
             foreach (int eid in vertex_edges.ValueItr(vID)) {
                 foreach (int tid in edge_triangles.ValueItr(eid)) {
                     if (vTriangles.Contains(tid) == false)
@@ -1040,6 +1039,31 @@ namespace g4
                         return false;
             }
             return true;            
+        }
+
+        public bool IsManifold()
+        {
+            for (int i = 0; i < EdgeCount; i++)
+            {
+                if (IsNonManifoldEdge(i))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public bool HasSelfIntersections()
+        {
+            var tree = new NTMeshAABBTree3(this, true);
+            return tree.FindAllSelfIntersectionsTriangles().TrianglePairs.Count > 0;
+        }
+
+        public int NumberOfComponents()
+        {
+            var meshConnectedComponents = new NTMeshConnectedComponents(this);
+            meshConnectedComponents.FindConnectedT();
+            return meshConnectedComponents.Count;
         }
 
         public bool CachedIsClosed {

--- a/mesh/NTMeshEditor.cs
+++ b/mesh/NTMeshEditor.cs
@@ -1,0 +1,1045 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+
+namespace g4
+{
+    // This class implements various ways to do low-level edits to a mesh, in
+    // a robust/reliable way.
+    //   - if operations fail in-progress, we try to back them out
+    //   - (?)
+    //
+    // 
+    public class NTMeshEditor
+    {
+        public NTMesh3 Mesh;
+
+
+        public NTMeshEditor(NTMesh3 mesh)
+        {
+            Mesh = mesh;
+        }
+
+
+
+        public virtual int[] AddTriangleStrip(IList<Frame3f> frames, IList<Interval1d> spans, int group_id = -1)
+        {
+            int N = frames.Count;
+            if (N != spans.Count)
+                throw new Exception("MeshEditor.AddTriangleStrip: spans list is not the same size!");
+            int[] new_tris = new int[2*(N-1)];
+
+            int prev_a = -1, prev_b = -1;
+            int i = 0, ti = 0;
+            for (i = 0; i < N; ++i) {
+                Frame3f f = frames[i];
+                Interval1d span = spans[i];
+
+                Vector3d va = f.Origin + (float)span.a * f.Y;
+                Vector3d vb = f.Origin + (float)span.b * f.Y;
+
+                // [TODO] could compute normals here...
+
+                int a = Mesh.AppendVertex(va);
+                int b = Mesh.AppendVertex(vb);
+
+                if ( prev_a != -1 ) {
+                    new_tris[ti++] = Mesh.AppendTriangle(prev_a, b, prev_b);
+                    new_tris[ti++] = Mesh.AppendTriangle(prev_a, a, b);
+
+                }
+                prev_a = a; prev_b = b;
+            }
+
+            return new_tris;
+        }
+
+
+
+
+
+        public virtual int[] AddTriangleFan_OrderedVertexLoop(int center, int[] vertex_loop, int group_id = -1)
+        {
+            int N = vertex_loop.Length;
+            int[] new_tris = new int[N];
+
+            int i = 0;
+            for ( i = 0; i < N; ++i ) {
+                int a = vertex_loop[i];
+                int b = vertex_loop[(i + 1) % N];
+
+                Index3i newT = new Index3i(center, b, a);
+                int new_tid = Mesh.AppendTriangle(newT, group_id);
+                if (new_tid < 0)
+                    goto operation_failed;
+
+                new_tris[i] = new_tid;
+            }
+
+            return new_tris;
+
+
+            operation_failed:
+                // remove what we added so far
+                if (i > 0) {
+                    if (remove_triangles(new_tris, i) == false)
+                        throw new Exception("MeshEditor.AddTriangleFan_OrderedVertexLoop: failed to add fan, and also falied to back out changes.");
+                }
+                return null;
+        }
+
+
+
+
+
+        public virtual int[] AddTriangleFan_OrderedEdgeLoop(int center, int[] edge_loop, int group_id = -1)
+        {
+            int N = edge_loop.Length;
+            int[] new_tris = new int[N];
+
+            int i = 0;
+            for ( i = 0; i < N; ++i ) {
+                if (Mesh.IsBoundaryEdge(edge_loop[i]) == false)
+                    goto operation_failed;
+
+                Index2i ev = Mesh.GetOrientedBoundaryEdgeV(edge_loop[i]);
+                int a = ev.a, b = ev.b;
+
+                Index3i newT = new Index3i(center, b, a);
+                int new_tid = Mesh.AppendTriangle(newT, group_id);
+                if (new_tid < 0)
+                    goto operation_failed;
+
+                new_tris[i] = new_tid;
+            }
+
+            return new_tris;
+
+
+            operation_failed:
+                // remove what we added so far
+                if (i > 0) {
+                    if (remove_triangles(new_tris, i-1) == false)
+                        throw new Exception("MeshEditor.AddTriangleFan_OrderedEdgeLoop: failed to add fan, and also failed to back out changes.");
+                }
+                return null;
+        }
+
+
+
+
+        /// <summary>
+        /// Trivial back-and-forth stitch between two vertex loops with same length. 
+        /// Loops must have appropriate orientation (which is...??)
+        /// [TODO] check and fail on bad orientation
+        /// </summary>
+        public virtual int[] StitchLoop(int[] vloop1, int[] vloop2, int group_id = -1)
+        {
+            int N = vloop1.Length;
+            if (N != vloop2.Length)
+                throw new Exception("MeshEditor.StitchLoop: loops are not the same length!!");
+
+            int[] new_tris = new int[N * 2];
+
+            int i = 0;
+            for ( ; i < N; ++i ) {
+                int a = vloop1[i];
+                int b = vloop1[(i + 1) % N];
+                int c = vloop2[i];
+                int d = vloop2[(i + 1) % N];
+
+                Index3i t1 = new Index3i(b, a, d);
+                Index3i t2 = new Index3i(a, c, d);
+
+                int tid1 = Mesh.AppendTriangle(t1, group_id);
+                int tid2 = Mesh.AppendTriangle(t2, group_id);
+                new_tris[2 * i] = tid1;
+                new_tris[2 * i + 1] = tid2;
+
+                if (tid1 < 0 || tid2 < 0)
+                    goto operation_failed;
+            }
+
+            return new_tris;
+
+
+            operation_failed:
+                // remove what we added so far
+                if (i > 0) {
+                    if (remove_triangles(new_tris, 2*i+1) == false)
+                        throw new Exception("MeshEditor.StitchLoop: failed to add all triangles, and also failed to back out changes.");
+                }
+                return null;
+        }
+
+
+
+
+
+
+
+        /// <summary>
+        /// Trivial back-and-forth stitch between two vertex loops with same length. 
+        /// If nearest vertices of input loops would not be matched, cycles loops so
+        /// that this is the case. 
+        /// Loops must have appropriate orientation.
+        /// </summary>
+        public virtual int[] StitchVertexLoops_NearestV(int[] loop0, int[] loop1, int group_id = -1)
+        {
+            int N = loop0.Length;
+            Index2i iBestPair = Index2i.Zero;
+            double best_dist = double.MaxValue;
+            for (int i = 0; i < N; ++i) {
+                Vector3d v0 = Mesh.GetVertex(loop0[i]);
+                for (int j = 0; j < N; ++j) {
+                    double dist_sqr = v0.DistanceSquared(Mesh.GetVertex(loop1[j]));
+                    if (dist_sqr < best_dist) {
+                        best_dist = dist_sqr;
+                        iBestPair = new Index2i(i, j);
+                    }
+                }
+            }
+            if (iBestPair.a != iBestPair.b) {
+                int[] newLoop0 = new int[N];
+                int[] newLoop1 = new int[N];
+                for (int i = 0; i < N; ++i) {
+                    newLoop0[i] = loop0[(iBestPair.a + i) % N];
+                    newLoop1[i] = loop1[(iBestPair.b + i) % N];
+                }
+                return StitchLoop(newLoop0, newLoop1, group_id);
+            } else {
+                return StitchLoop(loop0, loop1, group_id);
+            }
+
+        }
+
+
+
+
+
+
+        /// <summary>
+        /// Stitch two sets of boundary edges that are provided as unordered pairs of edges, by
+        /// adding triangulated quads between each edge pair. 
+        /// If bAbortOnFailure==true and a failure is encountered during stitching, the triangles added up to that point are removed.
+        /// If bAbortOnFailure==false, failures are ignored and the returned triangle list may contain invalid values!
+        /// </summary>
+        public virtual int[] StitchUnorderedEdges(List<Index2i> EdgePairs, int group_id, bool bAbortOnFailure, out bool stitch_incomplete)
+        {
+            int N = EdgePairs.Count;
+            int[] new_tris = new int[N * 2];
+            if (bAbortOnFailure == false) {
+                for (int k = 0; k < new_tris.Length; ++k)
+                    new_tris[k] = DMesh3.InvalidID;
+            }
+            stitch_incomplete = false;
+
+            int i = 0;
+            for (; i < N; ++i) {
+                Index2i edges = EdgePairs[i];
+
+                // look up and orient the first edge
+                var edge_vertices_a = Mesh.GetEdgeV(edges.a);
+                var edge_triangles_a = Mesh.EdgeTrianglesItr(edges.a).ToList();
+                //Index4i edge_a = Mesh.GetEdge(edges.a);
+                if (edge_triangles_a.Count != 1) {
+                    if (bAbortOnFailure) goto operation_failed;
+                    else { stitch_incomplete = true; continue; }
+                }
+                Index3i edge_a_tri = Mesh.GetTriangle(edge_triangles_a[0]);
+                int a = edge_vertices_a.a, b = edge_vertices_a.b;
+                IndexUtil.orient_tri_edge(ref a, ref b, edge_a_tri);
+
+                // look up and orient the second edge
+                var edge_vertices_b = Mesh.GetEdgeV(edges.a);
+                var edge_triangles_b = Mesh.EdgeTrianglesItr(edges.a).ToList();
+                if (edge_triangles_a.Count != 1) {
+                    if (bAbortOnFailure) goto operation_failed;
+                    else { stitch_incomplete = true; continue; }
+                }
+                Index3i edge_b_tri = Mesh.GetTriangle(edge_triangles_b[0]);
+                int c = edge_vertices_b.a, d = edge_vertices_b.b;
+                IndexUtil.orient_tri_edge(ref c, ref d, edge_b_tri);
+
+                // swap second edge (right? should this be a parameter?)
+                int tmp = c; c = d; d = tmp;
+
+                Index3i t1 = new Index3i(b, a, d);
+                Index3i t2 = new Index3i(a, c, d);
+
+                int tid1 = Mesh.AppendTriangle(t1, group_id);
+                int tid2 = Mesh.AppendTriangle(t2, group_id);
+
+                if (tid1 < 0 || tid2 < 0) {
+                    if (bAbortOnFailure) goto operation_failed;
+                    else { stitch_incomplete = true; continue; }
+                }
+
+                new_tris[2 * i] = tid1;
+                new_tris[2 * i + 1] = tid2;
+            }
+
+            return new_tris;
+
+            operation_failed:
+            // remove what we added so far
+            if (i > 0) {
+                if (remove_triangles(new_tris, 2 * (i - 1)) == false)
+                    throw new Exception("MeshEditor.StitchLoop: failed to add all triangles, and also failed to back out changes.");
+            }
+            return null;
+        }
+        public virtual int[] StitchUnorderedEdges(List<Index2i> EdgePairs, int group_id = -1, bool bAbortOnFailure = true)
+        {
+            bool incomplete = false;
+            return StitchUnorderedEdges(EdgePairs, group_id, bAbortOnFailure, out incomplete);
+        }
+
+
+
+
+
+
+        /// <summary>
+        /// Trivial back-and-forth stitch between two vertex spans with same length. 
+        /// vertex ordering must reslut in appropriate orientation (which is...??)
+        /// [TODO] check and fail on bad orientation
+        /// </summary>
+        public virtual int[] StitchSpan(IList<int> vspan1, IList<int> vspan2, int group_id = -1)
+        {
+            int N = vspan1.Count;
+            if (N != vspan2.Count)
+                throw new Exception("MeshEditor.StitchSpan: spans are not the same length!!");
+            N--;
+
+            int[] new_tris = new int[N * 2];
+
+            int i = 0;
+            for ( ; i < N; ++i ) {
+                int a = vspan1[i];
+                int b = vspan1[i + 1];
+                int c = vspan2[i];
+                int d = vspan2[i + 1];
+
+                Index3i t1 = new Index3i(b, a, d);
+                Index3i t2 = new Index3i(a, c, d);
+
+                int tid1 = Mesh.AppendTriangle(t1, group_id);
+                int tid2 = Mesh.AppendTriangle(t2, group_id);
+
+                if (tid1 < 0 || tid2 < 0)
+                    goto operation_failed;
+
+                new_tris[2 * i] = tid1;
+                new_tris[2 * i + 1] = tid2;
+            }
+
+            return new_tris;
+
+
+            operation_failed:
+                // remove what we added so far
+                if (i > 0) {
+                    if (remove_triangles(new_tris, 2*(i-1)) == false)
+                        throw new Exception("MeshEditor.StitchLoop: failed to add all triangles, and also failed to back out changes.");
+                }
+                return null;
+        }
+
+
+
+
+
+
+
+        // [TODO] cannot back-out this operation right now
+        //
+        // Remove list of triangles. Values of triangles[] set to InvalidID are ignored.
+        public bool RemoveTriangles(IList<int> triangles, bool bRemoveIsolatedVerts)
+        {
+            bool bAllOK = true;
+            for (int i = 0; i < triangles.Count; ++i ) {
+                if (triangles[i] == DMesh3.InvalidID)
+                    continue;
+
+                MeshResult result = Mesh.RemoveTriangle(triangles[i], bRemoveIsolatedVerts, false);
+                if (result != MeshResult.Ok)
+                    bAllOK = false;
+            }
+            return bAllOK;
+        }
+
+        // [TODO] cannot back-out this operation right now
+        //
+        // Remove list of triangles. Values of triangles[] set to InvalidID are ignored.
+        public bool RemoveTriangles(IEnumerable<int> triangles, bool bRemoveIsolatedVerts)
+        {
+            bool bAllOK = true;
+            foreach ( int tid in triangles ) {
+                if (! Mesh.IsTriangle(tid) ) {
+                    bAllOK = false;
+                    continue;
+                }
+                MeshResult result = Mesh.RemoveTriangle(tid, bRemoveIsolatedVerts, false);
+                if (result != MeshResult.Ok)
+                    bAllOK = false;
+            }
+            return bAllOK;
+        }
+
+        // [TODO] cannot back-out this operation right now
+        //
+        // Remove all triangles identified by selectorF returning true
+        public bool RemoveTriangles(Func<int,bool> selectorF, bool bRemoveIsolatedVerts)
+        {
+            bool bAllOK = true;
+            int NT = Mesh.MaxTriangleID;
+            for ( int ti = 0; ti < NT; ++ti ) {
+                if (Mesh.IsTriangle(ti) == false || selectorF(ti) == false)
+                    continue;
+                MeshResult result = Mesh.RemoveTriangle(ti, bRemoveIsolatedVerts, false);
+                if (result != MeshResult.Ok)
+                    bAllOK = false;
+            }
+            return bAllOK;
+        }
+
+        public static bool RemoveTriangles(DMesh3 Mesh, IList<int> triangles, bool bRemoveIsolatedVerts = true) {
+            MeshEditor editor = new MeshEditor(Mesh);
+            return editor.RemoveTriangles(triangles, bRemoveIsolatedVerts);
+        }
+        public static bool RemoveTriangles(DMesh3 Mesh, IEnumerable<int> triangles, bool bRemoveIsolatedVerts = true) {
+            MeshEditor editor = new MeshEditor(Mesh);
+            return editor.RemoveTriangles(triangles, bRemoveIsolatedVerts);
+        }
+
+
+        /// <summary>
+        /// Remove 'loner' triangles that have no connected neighbours. 
+        /// </summary>
+        public static bool RemoveIsolatedTriangles(DMesh3 mesh)
+        {
+            MeshEditor editor = new MeshEditor(mesh);
+            return editor.RemoveTriangles((tid) => {
+                Index3i tnbrs = mesh.GetTriNeighbourTris(tid);
+                return (tnbrs.a == DMesh3.InvalidID && tnbrs.b == DMesh3.InvalidID && tnbrs.c == DMesh3.InvalidID);
+            }, true);
+        }
+
+
+
+        /// <summary>
+        /// Remove 'fin' triangles that have only one connected triangle.
+        /// Removing one fin can create another, by default will keep iterating
+        /// until all fins removed (in a not very efficient way!).
+        /// Pass bRepeatToConvergence=false to only do one pass.
+        /// [TODO] if we are repeating, construct face selection from nbrs of first list and iterate over that on future passes!
+        /// </summary>
+        public static int RemoveFinTriangles(DMesh3 mesh, Func<DMesh3, int, bool> removeF = null, bool bRepeatToConvergence = true)
+        {
+            MeshEditor editor = new MeshEditor(mesh);
+
+            int nRemoved = 0;
+            List<int> to_remove = new List<int>();
+            repeat:
+            foreach ( int tid in mesh.TriangleIndices()) {
+                Index3i nbrs = mesh.GetTriNeighbourTris(tid);
+                int c = ((nbrs.a != DMesh3.InvalidID)?1:0) + ((nbrs.b != DMesh3.InvalidID)?1:0) + ((nbrs.c != DMesh3.InvalidID)?1:0);
+                if (c <= 1) {
+                    if (removeF == null || removeF(mesh, tid) == true )
+                        to_remove.Add(tid);
+                }
+            }
+            if (to_remove.Count == 0)
+                return nRemoved;
+            nRemoved += to_remove.Count;
+            RemoveTriangles(mesh, to_remove, true);
+            to_remove.Clear();
+            if (bRepeatToConvergence)
+                goto repeat;
+            return nRemoved;
+        }
+
+
+
+        /// <summary>
+        /// Disconnect the given triangles from their neighbours, by duplicating "boundary" vertices, ie
+        /// vertices on edges for which one triangle is in-set and the other is not. 
+        /// If bComputeEdgePairs is true, we return list of old/new edge pairs (useful for stitching)
+        /// [TODO] currently boundary-edge behaviour is to *not* duplicate boundary verts
+        /// </summary>
+        public bool SeparateTriangles(IEnumerable<int> triangles, bool bComputeEdgePairs, out List<Index2i> EdgePairs)
+        {
+            HashSet<int> in_set = new HashSet<int>(triangles);
+            Dictionary<int, int> VertexMap = new Dictionary<int, int>();
+            EdgePairs = null;
+            HashSet<int> edges = null;
+            List<Index2i> OldEdgeVerts = null;
+            if (bComputeEdgePairs) {
+                EdgePairs = new List<Index2i>();
+                edges = new HashSet<int>();
+                OldEdgeVerts = new List<Index2i>();
+            }
+
+            // duplicate vertices on edges that are on boundary of triangles roi
+            foreach ( int tid in triangles ) {
+                Index3i te = Mesh.GetTriEdges(tid);
+
+                for ( int j = 0; j < 3; ++j ) {
+                    var et = Mesh.EdgeTrianglesItr(te[j]);
+
+                    if (et.Count() <= 1 || (et.Contains(tid) && et.Any(t => in_set.Contains(t))))
+                        te[j] = -1;
+                }
+
+                for ( int j = 0; j < 3; ++j ) {
+                    if (te[j] == -1)
+                        continue;
+                    Index2i ev = Mesh.GetEdgeV(te[j]);
+                    if (VertexMap.ContainsKey(ev.a) == false)
+                        VertexMap[ev.a] = Mesh.AppendVertex(Mesh, ev.a);
+                    if (VertexMap.ContainsKey(ev.b) == false)
+                        VertexMap[ev.b] = Mesh.AppendVertex(Mesh, ev.b);
+
+                    if (bComputeEdgePairs && edges.Contains(te[j]) == false) {
+                        edges.Add(te[j]);
+                        OldEdgeVerts.Add(ev);
+                        EdgePairs.Add(new Index2i(te[j], -1));
+                    }
+                }
+            }
+
+            // update triangles
+            foreach ( int tid in triangles ) {
+                Index3i tv = Mesh.GetTriangle(tid);
+                Index3i tv_new = tv;
+                for ( int j = 0; j < 3; ++j ) {
+                    int newv;
+                    if (VertexMap.TryGetValue(tv[j], out newv)) 
+                        tv_new[j] = newv;
+                }
+                if ( tv_new != tv ) {
+                    Mesh.SetTriangle(tid, tv_new);
+                }
+            }
+
+            if ( bComputeEdgePairs ) {
+                for ( int k = 0; k < EdgePairs.Count; ++k ) {
+                    Index2i old_ev = OldEdgeVerts[k];
+                    int new_a = VertexMap[old_ev.a];
+                    int new_b = VertexMap[old_ev.b];
+                    int new_eid = Mesh.FindEdge(new_a, new_b);
+                    Util.gDevAssert(new_eid != DMesh3.InvalidID);
+                    EdgePairs[k] = new Index2i(EdgePairs[k].a, new_eid);
+                }
+            }
+
+            return true;
+        }
+
+
+
+        /// <summary>
+        /// Make a copy of provided triangles, with new vertices. You provide MapV because
+        /// you know if you are doing a small subset or a full-mesh-copy.
+        /// </summary>
+        public List<int> DuplicateTriangles(IEnumerable<int> triangles, ref IndexMap MapV, int group_id = -1)
+        {
+            List<int> new_triangles = new List<int>();
+            foreach ( int tid in triangles ) {
+                Index3i tri = Mesh.GetTriangle(tid);
+                for (int j = 0; j < 3; ++j) {
+                    int vid = tri[j];
+                    if (MapV.Contains(vid) == false) {
+                        int new_vid = Mesh.AppendVertex(Mesh, vid);
+                        MapV[vid] = new_vid;
+                        tri[j] = new_vid;
+                    } else {
+                        tri[j] = MapV[vid];
+                    }
+                }
+                int new_tid = Mesh.AppendTriangle(tri, group_id);
+                new_triangles.Add(new_tid);
+            }
+            return new_triangles;
+        }
+
+
+
+        /// <summary>
+        /// Reverse face orientation on a subset of triangles
+        /// </summary>
+        public void ReverseTriangles(IEnumerable<int> triangles, bool bFlipVtxNormals = true)
+        {
+            if ( bFlipVtxNormals == false ) { 
+                foreach (int tid in triangles) {
+                    Mesh.ReverseTriOrientation(tid);
+                }
+
+            } else {
+                BitArray donev = new BitArray(Mesh.MaxVertexID);
+
+                foreach (int tid in triangles) {
+                    Mesh.ReverseTriOrientation(tid);
+
+                    Index3i tri = Mesh.GetTriangle(tid);
+                    for (int j = 0; j < 3; ++j) {
+                        int vid = tri[j];
+                        if (donev[vid] == false) {
+                            Mesh.SetVertexNormal(vid, -Mesh.GetVertexNormal(vid));
+                            donev[vid] = true;
+                        }
+                    }
+                }
+            }
+
+        }
+
+
+
+        /// <summary>
+        /// separate triangle one-ring at vertex into connected components, and
+        /// then duplicate vertex once for each component
+        /// </summary>
+        public void DisconnectBowtie(int vid)
+        {
+            List<List<int>> sets = new List<List<int>>();
+            foreach ( int tid in Mesh.VtxTrianglesItr(vid)) {
+                var nbrs = Mesh.TriTrianglesItr(tid);
+                bool found = false;
+                foreach ( List<int> set in sets ) {
+                    if ( nbrs.Any(t => set.Contains(t))) {
+                        set.Add(tid);
+                        found = true;
+                        break;
+                    }
+                }
+                if ( found == false ) {
+                    List<int> set = new List<int>() { tid };
+                    sets.Add(set);
+                }
+            }
+            if (sets.Count == 1)
+                return;  // not a bowtie!
+            sets.Sort(bowtie_sorter);
+            for ( int k = 1; k < sets.Count; ++k ) {
+                int copy_vid = Mesh.AppendVertex(Mesh, vid);
+                List<int> tris = sets[k];
+                foreach ( int tid in tris ) {
+                    Index3i t = Mesh.GetTriangle(tid);
+                    if (t.a == vid) t.a = copy_vid;
+                    else if (t.b == vid) t.b = copy_vid;
+                    else t.c = copy_vid;
+                    Mesh.SetTriangle(tid, t, false);
+                }
+            }
+        }
+        static int bowtie_sorter(List<int> l1, List<int> l2) {
+            if (l1.Count == l2.Count) return 0;
+            return (l1.Count > l2.Count) ? -1 : 1;
+        }
+
+
+
+        /// <summary>
+        /// Disconnect all bowtie vertices in mesh. Iterates because sometimes
+		/// disconnecting a bowtie creates new bowties (how??).
+		/// Returns number of remaining bowties after iterations.
+        /// </summary>
+        public int DisconnectAllBowties(int nMaxIters = 10)
+        {
+            List<int> bowties = new List<int>(MeshIterators.BowtieVertices(Mesh));
+            int iter = 0;
+            while (bowties.Count > 0 && iter++ < nMaxIters) {
+                foreach (int vid in bowties) 
+                    DisconnectBowtie(vid);
+                bowties = new List<int>(MeshIterators.BowtieVertices(Mesh));
+            }
+			return bowties.Count;
+        }
+
+
+
+
+        // in ReinsertSubmesh, a problem can arise where the mesh we are inserting has duplicate triangles of
+        // the base mesh. This can lead to problematic behavior later. We can do various things, like delete
+        // and replace that existing triangle, or just use it instead of adding a new one. Or fail, or ignore it.
+        // This enum/argument controls the behavior. 
+        // However, fundamentally this kind of problem should be handled upstream!! For example by not trying
+        // to remesh areas that contain nonmanifold geometry...
+        public enum DuplicateTriBehavior
+        {
+            AssertContinue,         // check will not be done in Release!
+            AssertAbort, UseExisting, Replace
+        }
+
+
+        // Assumption here is that Submesh has been modified, but boundary loop has
+        // been preserved, and that old submesh has already been removed from this mesh.
+        // So, we just have to append new vertices and then rewrite triangles
+        // If new_tris or new_verts is non-null, we will return this info.
+        // new_tris should be set to TriangleCount (ie it is not necessarily a map)
+        // For new_verts, if we used an existing bdry vtx instead, we set the value to -(existing_index+1),
+        // otherwise the value is new_index (+1 is to handle 0)
+        //
+        // Returns true if submesh successfully inserted, false if any triangles failed
+        // (which happens if triangle would result in non-manifold mesh)
+        //public bool ReinsertSubmesh(NTSubmesh3 sub, ref int[] new_tris, out IndexMap SubToNewV,
+        //    DuplicateTriBehavior eDuplicateBehavior = DuplicateTriBehavior.AssertAbort)
+        //{
+        //    if (sub.BaseBorderV == null)
+        //        throw new Exception("MeshEditor.ReinsertSubmesh: Submesh does not have required boundary info. Call ComputeBoundaryInfo()!");
+
+        //    NTMesh3 submesh = sub.SubMesh;
+        //    bool bAllOK = true;
+
+        //    IndexFlagSet done_v = new IndexFlagSet(submesh.MaxVertexID, submesh.TriangleCount/2);
+        //    SubToNewV = new IndexMap(submesh.MaxVertexID, submesh.VertexCount);
+
+        //    int nti = 0;
+        //    int NT = submesh.MaxTriangleID;
+        //    for (int ti = 0; ti < NT; ++ti ) {
+        //        if (submesh.IsTriangle(ti) == false)
+        //            continue;
+
+        //        Index3i sub_t = submesh.GetTriangle(ti);
+        //        int gid = submesh.GetTriangleGroup(ti);
+
+        //        Index3i new_t = Index3i.Zero;
+        //        for ( int j = 0; j < 3; ++j ) {
+        //            int sub_v = sub_t[j];
+        //            int new_v = -1;
+        //            if (done_v[sub_v] == false) {
+
+        //                // first check if this is a boundary vtx on submesh and maps to a bdry vtx on base mesh
+        //                if (submesh.IsBoundaryVertex(sub_v)) {
+        //                    int base_v = (sub_v < sub.SubToBaseV.size) ? sub.SubToBaseV[sub_v] : -1;
+        //                    if ( base_v >= 0 && Mesh.IsVertex(base_v) && sub.BaseBorderV[base_v] == true ) { 
+        //                        // [RMS] this should always be true, but assert in tests to find out
+        //                        Debug.Assert(Mesh.IsBoundaryVertex(base_v));
+        //                        if (Mesh.IsBoundaryVertex(base_v)) {
+        //                            new_v = base_v;
+        //                        }
+        //                    }
+        //                }
+
+        //                // if that didn't happen, append new vtx
+        //                if ( new_v == -1 ) {
+        //                    new_v = Mesh.AppendVertex(submesh, sub_v);
+        //                }
+
+        //                SubToNewV[sub_v] = new_v;
+        //                done_v[sub_v] = true;
+
+        //            } else 
+        //                new_v = SubToNewV[sub_v];
+
+        //            new_t[j] = new_v;
+        //        }
+
+        //        // try to handle duplicate-tri case
+        //        if (eDuplicateBehavior == DuplicateTriBehavior.AssertContinue) {
+        //            Debug.Assert(Mesh.FindTriangle(new_t.a, new_t.b, new_t.c) == DMesh3.InvalidID);
+        //        } else {
+        //            int existing_tid = Mesh.FindTriangle(new_t.a, new_t.b, new_t.c);
+        //            if (existing_tid != DMesh3.InvalidID) {
+        //                if (eDuplicateBehavior == DuplicateTriBehavior.AssertAbort) {
+        //                    Debug.Assert(existing_tid == DMesh3.InvalidID);
+        //                    return false;
+        //                } else if (eDuplicateBehavior == DuplicateTriBehavior.UseExisting) {
+        //                    if (new_tris != null)
+        //                        new_tris[nti++] = existing_tid;
+        //                    continue;
+        //                } else if (eDuplicateBehavior == DuplicateTriBehavior.Replace) {
+        //                    Mesh.RemoveTriangle(existing_tid, false);
+        //                }
+        //            }
+        //        }
+
+
+        //        int new_tid = Mesh.AppendTriangle(new_t, gid);
+        //        Debug.Assert(new_tid != DMesh3.InvalidID && new_tid != DMesh3.NonManifoldID);
+        //        if ( ! Mesh.IsTriangle(new_tid) )
+        //            bAllOK = false;
+
+        //        if (new_tris != null)
+        //            new_tris[nti++] = new_tid;
+        //    }
+
+        //    return bAllOK;
+        //}
+
+
+
+
+
+
+
+        public bool AppendMesh(IMesh appendMesh, int appendGID = -1)
+        {
+            int[] mapV;
+            return AppendMesh(appendMesh, out mapV, appendGID);
+        }
+        public bool AppendMesh(IMesh appendMesh, out int[] mapV, int appendGID = -1)
+        {
+            mapV = new int[appendMesh.MaxVertexID];
+            foreach (int vid in appendMesh.VertexIndices() ) {
+                
+                NewVertexInfo vinfo = appendMesh.GetVertexAll(vid);
+                int newvid = Mesh.AppendVertex(vinfo);
+                mapV[vid] = newvid;
+            }
+
+            foreach (int tid in appendMesh.TriangleIndices()) {
+                Index3i t = appendMesh.GetTriangle(tid);
+                t.a = mapV[t.a];
+                t.b = mapV[t.b];
+                t.c = mapV[t.c];
+                int gid = appendMesh.GetTriangleGroup(tid);
+                if (appendGID >= 0)
+                    gid = appendGID;
+                Mesh.AppendTriangle(t, gid);
+            }
+
+            return true;
+        }
+        public static DMesh3 Combine(params IMesh[] appendMeshes )
+        {
+            DMesh3 m = new DMesh3();
+            MeshEditor editor = new MeshEditor(m);
+            foreach ( var mesh in appendMeshes ) {
+                editor.AppendMesh(mesh, m.AllocateTriangleGroup());
+            }
+            return m;
+        }
+        public static void Append(DMesh3 appendTo, DMesh3 append)
+        {
+            MeshEditor editor = new MeshEditor(appendTo);
+            editor.AppendMesh(append, appendTo.AllocateTriangleGroup());
+        }
+
+
+        public bool AppendMesh(IMesh appendMesh, IndexMap mergeMapV, out int[] mapV, int appendGID = -1)
+        {
+            mapV = new int[appendMesh.MaxVertexID];
+            foreach (int vid in appendMesh.VertexIndices()) {
+                if (mergeMapV.Contains(vid)) {
+                    mapV[vid] = mergeMapV[vid];
+                } else {
+                    NewVertexInfo vinfo = appendMesh.GetVertexAll(vid);
+                    int newvid = Mesh.AppendVertex(vinfo);
+                    mapV[vid] = newvid;
+                }
+            }
+
+            foreach (int tid in appendMesh.TriangleIndices()) {
+                Index3i t = appendMesh.GetTriangle(tid);
+                t.a = mapV[t.a];
+                t.b = mapV[t.b];
+                t.c = mapV[t.c];
+                int gid = appendMesh.GetTriangleGroup(tid);
+                if (appendGID >= 0)
+                    gid = appendGID;
+                Mesh.AppendTriangle(t, gid);
+            }
+
+            return true;
+        }
+
+
+
+
+        public void AppendBox(Frame3f frame, float size)
+        {
+            AppendBox(frame, size * Vector3f.One);
+        }
+        public void AppendBox(Frame3f frame, Vector3f size)
+        {
+            AppendBox(frame, size, Colorf.White);
+        }
+        public void AppendBox(Frame3f frame, Vector3f size, Colorf color)
+        {
+            TrivialBox3Generator boxgen = new TrivialBox3Generator() {
+                Box = new Box3d(frame, size),
+                NoSharedVertices = false
+            };
+            boxgen.Generate();
+            DMesh3 mesh = new DMesh3();
+            boxgen.MakeMesh(mesh);
+            if (Mesh.HasVertexColors)
+                mesh.EnableVertexColors(color);
+            AppendMesh(mesh, Mesh.AllocateTriangleGroup());
+        }
+        public void AppendLine(Segment3d seg, float size)
+        {
+            Frame3f f = new Frame3f(seg.Center);
+            f.AlignAxis(2, (Vector3f)seg.Direction);
+            AppendBox(f, new Vector3f(size, size, seg.Extent));
+        }
+        public void AppendLine(Segment3d seg, float size, Colorf color)
+        {
+            Frame3f f = new Frame3f(seg.Center);
+            f.AlignAxis(2, (Vector3f)seg.Direction);
+            AppendBox(f, new Vector3f(size, size, seg.Extent), color);
+        }
+        public static void AppendBox(DMesh3 mesh, Vector3d pos, float size)
+        {
+            MeshEditor editor = new MeshEditor(mesh);
+            editor.AppendBox(new Frame3f(pos), size);
+        }
+        public static void AppendBox(DMesh3 mesh, Vector3d pos, float size, Colorf color)
+        {
+            MeshEditor editor = new MeshEditor(mesh);
+            editor.AppendBox(new Frame3f(pos), size*Vector3f.One, color);
+        }
+        public static void AppendBox(DMesh3 mesh, Vector3d pos, Vector3d normal, float size)
+        {
+            MeshEditor editor = new MeshEditor(mesh);
+            editor.AppendBox(new Frame3f(pos, normal), size);
+        }
+        public static void AppendBox(DMesh3 mesh, Vector3d pos, Vector3d normal, float size, Colorf color)
+        {
+            MeshEditor editor = new MeshEditor(mesh);
+            editor.AppendBox(new Frame3f(pos, normal), size*Vector3f.One, color);
+        }
+        public static void AppendBox(DMesh3 mesh, Frame3f frame, Vector3f size, Colorf color)
+        {
+            MeshEditor editor = new MeshEditor(mesh);
+            editor.AppendBox(frame, size, color);
+        }
+
+        public static void AppendLine(DMesh3 mesh, Segment3d seg, float size)
+        {
+            Frame3f f = new Frame3f(seg.Center);
+            f.AlignAxis(2, (Vector3f)seg.Direction);
+            MeshEditor editor = new MeshEditor(mesh);
+            editor.AppendBox(f, new Vector3f(size, size, seg.Extent));
+        }
+
+
+
+
+        public void AppendPathSolid(IEnumerable<Vector3d> vertices, double radius, Colorf color)
+        {
+            TubeGenerator tubegen = new TubeGenerator() {
+                Vertices = new List<Vector3d>(vertices),
+                Polygon = Polygon2d.MakeCircle(radius, 6),
+                NoSharedVertices = false
+            };
+            DMesh3 mesh = tubegen.Generate().MakeDMesh();
+            if (Mesh.HasVertexColors)
+                mesh.EnableVertexColors(color);
+            AppendMesh(mesh, Mesh.AllocateTriangleGroup());
+        }
+
+
+
+
+        /// <summary>
+        /// Remove all bowtie vertices in mesh. Makes one pass unless
+        ///   bRepeatUntilClean = true, in which case repeats until no more bowties found
+        /// Returns true if any vertices were removed
+        /// </summary>
+        public bool RemoveAllBowtieVertices(bool bRepeatUntilClean)
+        {
+            int nRemoved = 0;
+
+            while (true) {
+                List<int> bowties = new List<int>();
+                foreach (int vID in Mesh.VertexIndices()) {
+                    if (Mesh.IsBowtieVertex(vID))
+                        bowties.Add(vID);
+                }
+                if (bowties.Count == 0)
+                    break;
+
+                foreach (int vID in bowties) {
+                    MeshResult result = Mesh.RemoveVertex(vID, true, false);
+                    Debug.Assert(result == MeshResult.Ok);
+                    nRemoved++;
+                }
+                if (bRepeatUntilClean == false)
+                    break;
+            }
+            return (nRemoved > 0);
+        }
+
+
+
+
+
+
+
+        /// <summary>
+        /// Remove any unused vertices in mesh, ie vertices with no edges.
+        /// Returns number of removed vertices.
+        /// </summary>
+        public int RemoveUnusedVertices()
+        {
+            int nRemoved = 0;
+            int NV = Mesh.MaxVertexID;
+            for ( int vid = 0; vid < NV; ++vid) {
+                if (Mesh.IsVertex(vid) && Mesh.GetVtxEdgeCount(vid) == 0) {
+                    Mesh.RemoveVertex(vid);
+                    ++nRemoved;
+                }
+            }
+            return nRemoved;
+        }
+        public static int RemoveUnusedVertices(DMesh3 mesh) {
+            MeshEditor e = new MeshEditor(mesh); return e.RemoveUnusedVertices();
+        }
+
+
+
+
+
+
+        /// <summary>
+        /// Remove any connected components with volume &lt; min_volume area lt; min_area
+        /// </summary>
+        //public int RemoveSmallComponents(double min_volume, double min_area)
+        //{
+        //    var C = new NTMeshConnectedComponents(Mesh);
+        //    C.FindConnectedT();
+        //    if (C.Count == 1)
+        //        return 0;
+        //    int nRemoved = 0;
+        //    foreach (var comp in C.Components) {
+        //        Vector2d vol_area = MeshMeasurements.VolumeArea(Mesh, comp.Indices, Mesh.GetVertex);
+        //        if (vol_area.x < min_volume || vol_area.y < min_area) {
+        //            MeshEditor.RemoveTriangles(Mesh, comp.Indices);
+        //            nRemoved++;
+        //        }
+        //    }
+        //    return nRemoved;
+        //}
+        //public static int RemoveSmallComponents(DMesh3 mesh, double min_volume, double min_area) {
+        //    MeshEditor e = new MeshEditor(mesh); return e.RemoveSmallComponents(min_volume, min_area);
+        //}
+
+
+
+
+
+
+
+        // this is for backing out changes we have made...
+        bool remove_triangles(int[] tri_list, int count)
+        {
+            for (int i = 0; i < count; ++i) {
+                if (Mesh.IsTriangle(tri_list[i]) == false)
+                    continue;
+                MeshResult result = Mesh.RemoveTriangle(tri_list[i], false, false);
+                if (result != MeshResult.Ok)
+                    return false;
+            }
+            return true;
+        }
+
+
+    }
+}

--- a/mesh/NTMeshPointSets.cs
+++ b/mesh/NTMeshPointSets.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace g4
+{
+
+
+
+    /// <summary>
+    /// Present mesh edge midpoints as a point set
+    /// </summary>
+    public class NTMeshEdgeMidpoints : IPointSet
+    {
+        public NTMeshEdgeMidpoints(NTMesh3 mesh)
+        {
+            Mesh = mesh;
+        }
+
+        public NTMesh3 Mesh;
+
+        public int VertexCount { get { return Mesh.EdgeCount; } }
+        public int MaxVertexID { get { return Mesh.MaxEdgeID; } }
+
+        public bool HasVertexNormals { get { return false; } }
+        public bool HasVertexColors { get { return false; } }
+
+        public Vector3d GetVertex(int i) { return Mesh.GetEdgePoint(i, 0.5); }
+        public Vector3f GetVertexNormal(int i) { return Vector3f.AxisY; }
+        public Vector3f GetVertexColor(int i) { return Vector3f.One; }
+
+        public bool IsVertex(int vID) { return Mesh.IsEdge(vID); }
+
+        // iterators allow us to work with gaps in index space
+        public IEnumerable<int> VertexIndices()
+        {
+            return Mesh.EdgeIndices();
+        }
+
+        /// <summary>
+        /// Timestamp is incremented any time any change is made to the mesh
+        /// </summary>
+        public int Timestamp {
+            get { return Mesh.Timestamp; }
+        }
+    }
+
+
+
+
+    /// <summary>
+    /// Present mesh boundary-edge midpoints as a point set
+    /// </summary>
+    public class NTMeshBoundaryEdgeMidpoints : IPointSet
+    {
+        public NTMeshBoundaryEdgeMidpoints(NTMesh3 mesh)
+        {
+            Mesh = mesh;
+            // [RMS] we could count boundary edges really fast by iterating by +4's in
+            //  the mesh edge buffer... (also have to check that edge is valid though!)
+            num_boundary_edges = 0;
+            foreach (int eid in mesh.BoundaryEdgeIndices())
+                num_boundary_edges++;
+        }
+
+        int num_boundary_edges;
+        public NTMesh3 Mesh;
+
+        public int VertexCount { get { return num_boundary_edges; } }
+        public int MaxVertexID { get { return Mesh.MaxEdgeID; } }
+
+        public bool HasVertexNormals { get { return false; } }
+        public bool HasVertexColors { get { return false; } }
+
+        public Vector3d GetVertex(int i) { return Mesh.GetEdgePoint(i, 0.5); }
+        public Vector3f GetVertexNormal(int i) { return Vector3f.AxisY; }
+        public Vector3f GetVertexColor(int i) { return Vector3f.One; }
+
+        public bool IsVertex(int vID) { return Mesh.IsEdge(vID) && Mesh.IsBoundaryEdge(vID); }
+
+        // iterators allow us to work with gaps in index space
+        public IEnumerable<int> VertexIndices()
+        {
+            return Mesh.BoundaryEdgeIndices();
+        }
+
+        /// <summary>
+        /// Timestamp is incremented any time any change is made to the mesh
+        /// </summary>
+        public int Timestamp {
+            get { return Mesh.Timestamp; }
+        }
+    }
+
+
+}

--- a/mesh/NTSubmesh3.cs
+++ b/mesh/NTSubmesh3.cs
@@ -1,0 +1,233 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace g4
+{
+
+
+
+
+    public class NTSubmesh3
+    {
+        public NTMesh3 BaseMesh;
+        public NTMesh3 SubMesh;
+        public MeshComponents WantComponents = MeshComponents.All;
+        public bool ComputeTriMaps = false;
+        public int OverrideGroupID = -1;
+        
+        public IndexFlagSet BaseSubmeshV;       // vertices in base mesh that are in submesh
+                                                // (we compute this anyway, might as well hang onto it)
+
+        public IndexMap BaseToSubV;             // vertex index map from base to submesh 
+        public DVector<int> SubToBaseV;         // vertex index map from submesh to base mesh
+
+        public IndexMap BaseToSubT;             // triangle index map from base to submesh. Only computed if ComputeTriMaps = true.
+        public DVector<int> SubToBaseT;         // triangle index map from submesh to base mesh. Only computed if ComputeTriMaps = true.
+
+        // boundary info
+        public IndexHashSet BaseBorderE;        // list of internal border edge indices on base mesh. Does not include mesh boundary edges.
+        public IndexHashSet BaseBoundaryE;      // list of mesh-boundary edges on base mesh that are in submesh
+        public IndexHashSet BaseBorderV;        // list of border vertex indices on base mesh (ie verts of BaseBorderE - does not include mesh boundary vertices)
+
+
+        public NTSubmesh3(NTMesh3 mesh, int[] subTriangles)
+        {
+            BaseMesh = mesh;
+            compute(subTriangles, subTriangles.Length);
+        }
+        public NTSubmesh3(NTMesh3 mesh, IEnumerable<int> subTriangles, int nTriEstimate = 0)
+        {
+            BaseMesh = mesh;
+            compute(subTriangles, nTriEstimate);
+        }
+
+        public NTSubmesh3(NTMesh3 mesh)
+        {
+            BaseMesh = mesh;
+        }
+        public void Compute(int[] subTriangles) {
+            compute(subTriangles, subTriangles.Length);
+        }
+        public void Compute(IEnumerable<int> subTriangles, int nTriEstimate = 0) {
+            compute(subTriangles, nTriEstimate);
+        }
+
+        public int MapVertexToSubmesh(int base_vID) {
+            return BaseToSubV[base_vID];
+        }
+        public int MapVertexToBaseMesh(int sub_vID) {
+            if (sub_vID < SubToBaseV.Length)
+                return SubToBaseV[sub_vID];
+            return DMesh3.InvalidID;
+        }
+
+        public Index2i MapVerticesToSubmesh(Index2i v) {
+            return new Index2i(BaseToSubV[v.a], BaseToSubV[v.b]);
+        }
+        public Index2i MapVerticesToBaseMesh(Index2i v) {
+            return new Index2i(MapVertexToBaseMesh(v.a), MapVertexToBaseMesh(v.b));
+        }
+
+        public void MapVerticesToSubmesh(int[] vertices)
+        {
+            for (int i = 0; i < vertices.Length; ++i)
+                vertices[i] = BaseToSubV[vertices[i]];
+        }
+
+
+        public int MapEdgeToSubmesh(int base_eid)
+        {
+            Index2i base_ev = BaseMesh.GetEdgeV(base_eid);
+            Index2i sub_ev = MapVerticesToSubmesh(base_ev);
+            return SubMesh.FindEdge(sub_ev.a, sub_ev.b);
+        }
+        public void MapEdgesToSubmesh(int[] edges)
+        {
+            for (int i = 0; i < edges.Length; ++i)
+                edges[i] = MapEdgeToSubmesh(edges[i]);
+        }
+
+        public int MapEdgeToBaseMesh(int sub_eid)
+        {
+            Index2i sub_ev = SubMesh.GetEdgeV(sub_eid);
+            Index2i base_ev = MapVerticesToBaseMesh(sub_ev);
+            return BaseMesh.FindEdge(base_ev.a, base_ev.b);
+        }
+
+
+        public int MapTriangleToSubmesh(int base_tID)
+        {
+            if (ComputeTriMaps == false)
+                throw new InvalidOperationException("DSubmesh3.MapTriangleToSubmesh: must set ComputeTriMaps = true!");
+            return BaseToSubT[base_tID];
+        }
+        public int MapTriangleToBaseMesh(int sub_tID)
+        {
+            if (ComputeTriMaps == false)
+                throw new InvalidOperationException("DSubmesh3.MapTriangleToBaseMesh: must set ComputeTriMaps = true!");
+            if (sub_tID < SubToBaseT.Length)
+                return SubToBaseT[sub_tID];
+            return DMesh3.InvalidID;
+        }
+
+        public void MapTrianglesToSubmesh(int[] triangles)
+        {
+            if (ComputeTriMaps == false)
+                throw new InvalidOperationException("DSubmesh3.MapTrianglesToSubmesh: must set ComputeTriMaps = true!");
+            for (int i = 0; i < triangles.Length; ++i)
+                triangles[i] = BaseToSubT[triangles[i]];
+        }
+
+
+
+
+        public void ComputeBoundaryInfo(int[] subTriangles) {
+            ComputeBoundaryInfo(subTriangles, subTriangles.Length);
+        }
+        public void ComputeBoundaryInfo(IEnumerable<int> triangles, int tri_count_est)
+        {
+            // set of base-mesh triangles that are in submesh
+            IndexFlagSet sub_tris = new IndexFlagSet(BaseMesh.MaxTriangleID, tri_count_est);
+            foreach (int ti in triangles)
+                sub_tris[ti] = true;
+
+            BaseBorderV = new IndexHashSet();
+            BaseBorderE = new IndexHashSet();
+            BaseBoundaryE = new IndexHashSet();
+
+            // Iterate through edges in submesh roi on base mesh. If
+            // one of the tris of the edge is not in submesh roi, then this
+            // is a boundary edge.
+            //
+            // (edge iteration via triangle iteration processes each internal edge twice...)
+            foreach (int ti in triangles) {
+                Index3i tedges = BaseMesh.GetTriEdges(ti);
+                for ( int j = 0; j < 3; ++j ) {
+                    int eid = tedges[j];
+
+                    var edgeTris = BaseMesh.EdgeTrianglesItr(eid).ToList();
+                    if (edgeTris.Count <= 1)
+                    {
+                        BaseBoundaryE[eid] = true;
+                    }
+                    else if (!edgeTris.All(t => sub_tris[t]))
+                    {
+                        BaseBorderE[eid] = true;
+                        Index2i ve = BaseMesh.GetEdgeV(eid);
+                        BaseBorderV[ve.a] = true;
+                        BaseBorderV[ve.b] = true;
+                    }
+                }
+            }
+            
+        }
+
+
+
+        // [RMS] estimate can be zero
+        void compute(IEnumerable<int> triangles, int tri_count_est )
+        {
+            int est_verts = tri_count_est / 2;
+
+            SubMesh = new NTMesh3( BaseMesh.Components & WantComponents );
+
+            BaseSubmeshV = new IndexFlagSet(BaseMesh.MaxVertexID, est_verts);
+            BaseToSubV = new IndexMap(BaseMesh.MaxVertexID, est_verts);
+            SubToBaseV = new DVector<int>();
+
+            if ( ComputeTriMaps ) {
+                BaseToSubT = new IndexMap(BaseMesh.MaxTriangleID, tri_count_est);
+                SubToBaseT = new DVector<int>();
+            }
+
+            foreach ( int tid in triangles ) {
+                if ( ! BaseMesh.IsTriangle(tid) )
+                    throw new Exception("DSubmesh3.compute: triangle " + tid + " does not exist in BaseMesh!");
+                Index3i base_t = BaseMesh.GetTriangle(tid);
+                Index3i new_t = Index3i.Zero;
+                int gid = BaseMesh.GetTriangleGroup(tid);
+
+                for ( int j = 0; j < 3; ++j ) {
+                    int base_v = base_t[j];
+                    int sub_v = -1;
+                    if (BaseSubmeshV[base_v] == false) {
+                        sub_v = SubMesh.AppendVertex(BaseMesh, base_v);
+                        BaseSubmeshV[base_v] = true;
+                        BaseToSubV[base_v] = sub_v;
+                        SubToBaseV.insert(base_v, sub_v);
+                    } else
+                        sub_v = BaseToSubV[base_v];
+                    new_t[j] = sub_v;
+                }
+
+                if (OverrideGroupID >= 0)
+                    gid = OverrideGroupID;
+                int sub_tid = SubMesh.AppendTriangle(new_t, gid);
+
+                if ( ComputeTriMaps ) {
+                    BaseToSubT[tid] = sub_tid;
+                    SubToBaseT.insert(tid, sub_tid);
+                }
+            }
+
+
+
+
+        }
+
+
+
+
+
+        public static DMesh3 QuickSubmesh(DMesh3 mesh, int[] triangles) {
+            DSubmesh3 submesh = new DSubmesh3(mesh, triangles);
+            return submesh.SubMesh;
+        }
+        public static DMesh3 QuickSubmesh(DMesh3 mesh, IEnumerable<int> triangles) {
+            return QuickSubmesh(mesh, triangles.ToArray());
+        }
+
+    }
+}

--- a/mesh_ops/NTMergeCoincidentEdges.cs
+++ b/mesh_ops/NTMergeCoincidentEdges.cs
@@ -1,0 +1,170 @@
+﻿// Copyright (c) Ryan Schmidt (rms@gradientspace.com) - All Rights Reserved
+// Distributed under the Boost Software License, Version 1.0. http://www.boost.org/LICENSE_1_0.txt
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using g4;
+
+namespace gs
+{
+	/// <summary>
+	/// Merge coincident edges.
+	/// </summary>
+	public class NTMergeCoincidentEdges
+	{
+		public NTMesh3 Mesh;
+
+		public double MergeDistance = MathUtil.ZeroTolerancef;
+
+        public bool OnlyUniquePairs = false;
+
+		public NTMergeCoincidentEdges(NTMesh3 mesh)
+		{
+			Mesh = mesh;
+		}
+
+		double merge_r2;
+
+		public virtual bool Apply() {
+			merge_r2 = MergeDistance * MergeDistance;
+
+            // construct hash table for edge midpoints
+            var pointset = new NTMeshBoundaryEdgeMidpoints(this.Mesh);
+			var hash = new PointSetHashtable(pointset);
+
+            AxisAlignedBox3d bounds = BoundsUtil.Bounds(pointset);
+            int maxHashN = (int) (bounds.MaxDim / MergeDistance) - 1;
+
+			if (maxHashN < 1)
+			{
+				return false;
+			}
+
+            int hashN = 64;
+            if (Mesh.TriangleCount > 100000)   hashN = 128;
+            if (Mesh.TriangleCount > 1000000)  hashN = 256;
+			hashN = Math.Min(hashN, maxHashN);
+			hash.Build(hashN);
+
+			Vector3d a = Vector3d.Zero, b = Vector3d.Zero;
+			Vector3d c = Vector3d.Zero, d = Vector3d.Zero;
+
+			// find edge equivalence sets. First we find all other edges with same
+			// midpoint, and then we check if endpoints are the same in second loop
+			int[] buffer = new int[1024];
+			List<int>[] EquivSets = new List<int>[Mesh.MaxEdgeID];
+			HashSet<int> remaining = new HashSet<int>();
+			foreach ( int eid in Mesh.BoundaryEdgeIndices() ) {
+				Vector3d midpt = Mesh.GetEdgePoint(eid, 0.5);
+				int N;
+				while (hash.FindInBall(midpt, MergeDistance, buffer, out N) == false)
+					buffer = new int[buffer.Length];
+				if (N == 1 && buffer[0] != eid)
+					throw new Exception("MergeCoincidentEdges.Apply: how could this happen?!");
+				if (N <= 1)
+					continue;  // unique edge
+
+				Mesh.GetEdgeV(eid, ref a, ref b);
+
+				// if same endpoints, add to equivalence set
+				List<int> equiv = new List<int>(N - 1);
+				for (int i = 0; i < N; ++i) {
+					if (buffer[i] != eid) {
+						Mesh.GetEdgeV(buffer[i], ref c, ref d);
+						if ( is_same_edge(ref a, ref b, ref c, ref d))
+							equiv.Add(buffer[i]);
+					}
+				}
+				if (equiv.Count > 0) {
+					EquivSets[eid] = equiv;
+					remaining.Add(eid);
+				}
+			}
+
+			// [TODO] could replace remaining hashset w/ PQ, and use conservative count?
+
+			// add potential duplicate edges to priority queue, sorted by
+			// number of possible matches. 
+			// [TODO] Does this need to be a PQ? Not updating PQ below anyway...
+			DynamicPriorityQueue<DuplicateEdge> Q = new DynamicPriorityQueue<DuplicateEdge>();
+			foreach ( int i in remaining ) {
+                if (OnlyUniquePairs) {
+                    if (EquivSets[i].Count != 1)
+                        continue;
+                    foreach (int j in EquivSets[i]) {
+                        if (EquivSets[j].Count != 1 || EquivSets[j][0] != i)
+                            continue;
+                    }
+                }
+
+                Q.Enqueue(new DuplicateEdge() { eid = i }, EquivSets[i].Count);
+			}
+
+			while ( Q.Count > 0 ) {
+				DuplicateEdge e = Q.Dequeue();
+				if (Mesh.IsEdge(e.eid) == false || EquivSets[e.eid] == null || remaining.Contains(e.eid) == false )
+					continue;               // dealt with this edge already
+                if (Mesh.IsBoundaryEdge(e.eid) == false)
+                    continue;
+
+				List<int> equiv = EquivSets[e.eid];
+
+				// find viable match
+				// [TODO] how to make good decisions here? prefer planarity?
+				bool merged = false;
+				int failed = 0;
+				for (int i = 0; i < equiv.Count && merged == false; ++i ) {
+					int other_eid = equiv[i];
+					if ( Mesh.IsEdge(other_eid) == false || Mesh.IsBoundaryEdge(other_eid) == false )
+						continue;
+
+					NTMesh3.MergeEdgesInfo info;
+					MeshResult result = Mesh.MergeEdges(e.eid, other_eid, out info);
+					if ( result != MeshResult.Ok ) {
+						equiv.RemoveAt(i);
+                        i--;
+
+						EquivSets[other_eid].Remove(e.eid);
+						//Q.UpdatePriority(...);  // how need ref to queue node to do this...??
+						//   maybe equiv set is queue node??
+
+						failed++;
+					} else {
+						// ok we merged, other edge is no longer free
+						merged = true;
+						EquivSets[other_eid] = null;
+						remaining.Remove(other_eid);
+					}
+				}
+
+				if ( merged ) {
+					EquivSets[e.eid] = null;
+					remaining.Remove(e.eid);					
+				} else {
+					// should we do something else here? doesn't make sense to put
+					// back into Q, as it should be at the top, right?
+					EquivSets[e.eid] = null;
+					remaining.Remove(e.eid);
+				}
+
+			}
+
+			return true;
+		}
+
+
+
+		bool is_same_edge(ref Vector3d a, ref Vector3d b, ref Vector3d c, ref Vector3d d) {
+			return (a.DistanceSquared(c) < merge_r2 && b.DistanceSquared(d) < merge_r2) ||
+				(a.DistanceSquared(d) < merge_r2 && b.DistanceSquared(c) < merge_r2);
+		}
+
+
+
+		class DuplicateEdge : DynamicPriorityQueueNode {
+			public int eid;
+		}
+
+
+    }
+}

--- a/mesh_ops/NTMeshRepairOrientation.cs
+++ b/mesh_ops/NTMeshRepairOrientation.cs
@@ -1,0 +1,187 @@
+﻿// Copyright (c) Ryan Schmidt (rms@gradientspace.com) - All Rights Reserved
+// Distributed under the Boost Software License, Version 1.0. http://www.boost.org/LICENSE_1_0.txt
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using g4;
+
+namespace gs
+{
+    public class NTMeshRepairOrientation
+    {
+        public NTMesh3 Mesh;
+
+        NTMeshAABBTree3 spatial;
+        protected NTMeshAABBTree3 Spatial
+        {
+            get
+            {
+                if (spatial == null)
+                    spatial = new NTMeshAABBTree3(Mesh, true);
+                return spatial;
+            }
+        }
+
+        public NTMeshRepairOrientation(NTMesh3 mesh3, NTMeshAABBTree3 spatial = null)
+        {
+            Mesh = mesh3;
+            this.spatial = spatial;
+        }
+
+
+        class Component
+        {
+            public List<int> triangles;
+            public double outFacing;
+            public double inFacing;
+        }
+        List<Component> Components = new List<Component>();
+
+
+
+
+        // TODO:
+        //  - (in merge coincident) don't merge tris with same/opposite normals (option)
+        //  - after orienting components, try to find adjacent open components and
+        //    transfer orientation between them
+        //  - orient via nesting
+
+
+        public void OrientComponents()
+        {
+            Components = new List<Component>();
+
+            HashSet<int> remaining = new HashSet<int>(Mesh.TriangleIndices());
+            List<int> stack = new List<int>();
+            while (remaining.Count > 0)
+            {
+                Component c = new Component();
+                c.triangles = new List<int>();
+
+                stack.Clear();
+                int start = remaining.First();
+                remaining.Remove(start);
+                c.triangles.Add(start);
+                stack.Add(start);
+                while (stack.Count > 0)
+                {
+                    int cur = stack[stack.Count - 1];
+                    stack.RemoveAt(stack.Count - 1);
+                    Index3i tcur = Mesh.GetTriangle(cur);
+
+                    var nbrs = Mesh.TriTrianglesItr(cur).ToList();
+                    for (var j = 0; j < nbrs.Count; j++)
+                    {
+                        var nbr = nbrs[j];
+                        if (remaining.Contains(nbr) == false)
+                            continue;
+
+                        int a = tcur[j];
+                        int b = tcur[(j + 1) % 3];
+
+                        Index3i tnbr = Mesh.GetTriangle(nbr);
+                        if (IndexUtil.find_tri_ordered_edge(b, a, ref tnbr) == DMesh3.InvalidID)
+                        {
+                            Mesh.ReverseTriOrientation(nbr);
+                        }
+                        stack.Add(nbr);
+                        remaining.Remove(nbr);
+                        c.triangles.Add(nbr);
+                    }
+
+                }
+
+                Components.Add(c);
+            }
+        }
+
+
+
+
+
+        public void ComputeStatistics()
+        {
+            var s = this.Spatial;  // make sure this exists
+            // Cannot do in parallel because we set a filter on spatial DS. 
+            // Also we are doing rays in parallel anyway...
+            foreach (var c in Components)
+            {
+                compute_statistics(c);
+            }
+        }
+        void compute_statistics(Component c)
+        {
+            int NC = c.triangles.Count;
+            c.inFacing = c.outFacing = 0;
+            double dist = 2 * Mesh.CachedBounds.DiagonalLength;
+
+            // only want to raycast triangles in this 
+            HashSet<int> tris = new HashSet<int>(c.triangles);
+            spatial.TriangleFilterF = tris.Contains;
+
+            // We want to try to figure out what is 'outside' relative to the world.
+            // Assumption is that faces we can hit from far away should be oriented outwards.
+            // So, for each triangle we construct far-away points in positive and negative normal
+            // direction, then raycast back towards the triangle. If we hit the triangle from
+            // one side and not the other, that is evidence we should keep/reverse that triangle.
+            // If it is not hit, or hit from both, that does not provide any evidence.
+            // We collect up this keep/reverse evidence and use the larger to decide on the global orientation.
+
+            SpinLock count_lock = new SpinLock();
+
+            gParallel.BlockStartEnd(0, NC - 1, (a, b) => {
+                for (int i = a; i <= b; ++i)
+                {
+                    int ti = c.triangles[i];
+                    Vector3d normal, centroid; double area;
+                    Mesh.GetTriInfo(ti, out normal, out area, out centroid);
+                    if (area < MathUtil.ZeroTolerancef)
+                        continue;
+
+                    // construct far away points
+                    Vector3d pos_pt = centroid + dist * normal;
+                    Vector3d neg_pt = centroid - dist * normal;
+
+                    // raycast towards triangle from far-away point
+                    int hit_pos = spatial.FindNearestHitTriangle(new Ray3d(pos_pt, -normal));
+                    int hit_neg = spatial.FindNearestHitTriangle(new Ray3d(neg_pt, normal));
+                    if (hit_pos != ti && hit_neg != ti)
+                        continue;       // no evidence
+                    if (hit_pos == ti && hit_neg == ti)
+                        continue;       // no evidence (?)
+
+                    bool taken = false;
+                    count_lock.Enter(ref taken);
+
+                    if (hit_neg == ti)
+                        c.inFacing += area;
+                    else if (hit_pos == ti)
+                        c.outFacing += area;
+
+                    count_lock.Exit();
+                }
+            });
+
+            spatial.TriangleFilterF = null;
+        }
+
+
+
+        public void SolveGlobalOrientation()
+        {
+            ComputeStatistics();
+            var editor = new NTMeshEditor(Mesh);
+            foreach (Component c in Components)
+            {
+                if (c.inFacing > c.outFacing)
+                {
+                    editor.ReverseTriangles(c.triangles);
+                }
+            }
+        }
+
+
+
+    }
+}

--- a/mesh_ops/NTMeshRepairOrientation.cs
+++ b/mesh_ops/NTMeshRepairOrientation.cs
@@ -70,7 +70,25 @@ namespace gs
                     stack.RemoveAt(stack.Count - 1);
                     Index3i tcur = Mesh.GetTriangle(cur);
 
-                    var nbrs = Mesh.TriTrianglesItr(cur).ToList();
+                    var edges = Mesh.GetTriEdges(cur);
+
+                    var nbrs = new List<int>();
+                    if (!Mesh.IsNonManifoldEdge(edges.a))
+                    {
+                        nbrs.AddRange(Mesh.EdgeTrianglesItr(edges.a));
+                    }
+
+                    if (!Mesh.IsNonManifoldEdge(edges.b))
+                    {
+                        nbrs.AddRange(Mesh.EdgeTrianglesItr(edges.b));
+                    }
+
+                    if (!Mesh.IsNonManifoldEdge(edges.c))
+                    {
+                        nbrs.AddRange(Mesh.EdgeTrianglesItr(edges.c));
+                    }
+
+                    //var nbrs = Mesh.TriTrianglesItr(cur).ToList();
                     for (var j = 0; j < nbrs.Count; j++)
                     {
                         var nbr = nbrs[j];

--- a/mesh_ops/NTMeshRepairOrientation.cs
+++ b/mesh_ops/NTMeshRepairOrientation.cs
@@ -23,10 +23,9 @@ namespace gs
             }
         }
 
-        public NTMeshRepairOrientation(NTMesh3 mesh3, NTMeshAABBTree3 spatial = null)
+        public NTMeshRepairOrientation(NTMesh3 mesh3)
         {
             Mesh = mesh3;
-            this.spatial = spatial;
         }
 
 
@@ -46,7 +45,6 @@ namespace gs
         //  - after orienting components, try to find adjacent open components and
         //    transfer orientation between them
         //  - orient via nesting
-
 
         public void OrientComponents()
         {
@@ -88,21 +86,25 @@ namespace gs
                         nbrs.AddRange(Mesh.EdgeTrianglesItr(edges.c));
                     }
 
-                    //var nbrs = Mesh.TriTrianglesItr(cur).ToList();
                     for (var j = 0; j < nbrs.Count; j++)
                     {
                         var nbr = nbrs[j];
                         if (remaining.Contains(nbr) == false)
                             continue;
 
-                        int a = tcur[j];
-                        int b = tcur[(j + 1) % 3];
+                        int aVtx = tcur[0];
+                        int bVtx = tcur[1];
+                        int cVtx = tcur[2];
+
 
                         Index3i tnbr = Mesh.GetTriangle(nbr);
-                        if (IndexUtil.find_tri_ordered_edge(b, a, ref tnbr) == DMesh3.InvalidID)
+                        if (IndexUtil.find_tri_ordered_edge(bVtx, aVtx, ref tnbr) == DMesh3.InvalidID &&
+                            IndexUtil.find_tri_ordered_edge(cVtx, bVtx, ref tnbr) == DMesh3.InvalidID &&
+                            IndexUtil.find_tri_ordered_edge(aVtx, cVtx, ref tnbr) == DMesh3.InvalidID)
                         {
                             Mesh.ReverseTriOrientation(nbr);
                         }
+
                         stack.Add(nbr);
                         remaining.Remove(nbr);
                         c.triangles.Add(nbr);
@@ -198,8 +200,5 @@ namespace gs
                 }
             }
         }
-
-
-
     }
 }

--- a/mesh_ops/NTRegionOperator.cs
+++ b/mesh_ops/NTRegionOperator.cs
@@ -1,0 +1,211 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Diagnostics;
+
+namespace g4
+{
+    /// <summary>
+    /// This class automatically extracts a submesh from a mesh, and can re-insert it after you have
+    /// edited it, as long as you have not messed up the boundary
+    /// 
+    /// [TODO] Nearly all the code here is duplicated from RegionRemesher. Maybe this could be a base class for that?
+    /// [TODO] ReinsertSubToBaseMapT is not returned by the MeshEditor.ReinsertSubmesh, instead we are
+    ///   trying to guess it here, by making some assumptions about what happens. It works for now, but
+    ///   it would better if MeshEditor returned this information.
+    /// </summary>
+    public class NTRegionOperator
+    {
+        public NTMesh3 BaseMesh;
+        public NTSubmesh3 Region;
+
+        // this is only valid after BackPropagate() call!! maps submeshverts to base mesh
+        public IndexMap ReinsertSubToBaseMapV;
+
+        // [RMS] computation of this is kind of a hack right now...
+        public IndexMap ReinsertSubToBaseMapT;
+
+        // handle a tricky problem...see comments for DuplicateTriBehavior enum
+        public NTMeshEditor.DuplicateTriBehavior ReinsertDuplicateTriBehavior = NTMeshEditor.DuplicateTriBehavior.AssertContinue;
+
+        int[] cur_base_tris;
+
+        public NTRegionOperator(NTMesh3 mesh, int[] regionTris, Action<NTSubmesh3> submeshConfigF = null)
+        {
+            BaseMesh = mesh;
+            Region = new NTSubmesh3(mesh);
+            if (submeshConfigF != null)
+                submeshConfigF(Region);
+            Region.Compute(regionTris);
+            Region.ComputeBoundaryInfo(regionTris);
+
+            cur_base_tris = (int[])regionTris.Clone();
+        }
+
+        public NTRegionOperator(NTMesh3 mesh, IEnumerable<int> regionTris, Action<NTSubmesh3> submeshConfigF = null)
+        {
+            BaseMesh = mesh;
+            Region = new NTSubmesh3(mesh);
+            if (submeshConfigF != null)
+                submeshConfigF(Region);
+            Region.Compute(regionTris);
+            int count = regionTris.Count();
+            Region.ComputeBoundaryInfo(regionTris, count);
+
+            cur_base_tris = regionTris.ToArray();
+        }
+
+
+        /// <summary>
+        /// list of sub-region triangles. This is either the input regionTris,
+        /// or the submesh triangles after they are re-inserted.
+        /// </summary>
+        public int[] CurrentBaseTriangles {
+            get { return cur_base_tris; }
+        }
+
+
+        /// <summary>
+        /// find base-mesh interior vertices of region (ie does not include region boundary vertices)
+        /// </summary>
+        public HashSet<int> CurrentBaseInteriorVertices()
+        {
+            HashSet<int> verts = new HashSet<int>();
+            IndexHashSet borderv = Region.BaseBorderV;
+            foreach ( int tid in cur_base_tris ) {
+                Index3i tv = BaseMesh.GetTriangle(tid);
+                if (borderv[tv.a] == false) verts.Add(tv.a);
+                if (borderv[tv.b] == false) verts.Add(tv.b);
+                if (borderv[tv.c] == false) verts.Add(tv.c);
+            }
+            return verts;
+        }
+
+        // After remeshing we may create an internal edge between two boundary vertices [a,b].
+        // Those vertices will be merged with vertices c and d in the base mesh. If the edge
+        // [c,d] already exists in the base mesh, then after the merge we would have at least
+        // 3 triangles at this edge. Dang.
+        //
+        // A common example is a 'fin' triangle that would duplicate a
+        // 'fin' on the border of the base mesh after removing the submesh, but this situation can
+        // arise anywhere (eg think about one-triangle-wide strips).
+        //
+        // This is very hard to remove, but we can at least avoid creating non-manifold edges (which
+        // with the current DMesh3 will be prevented, hence leaving a hole) by splitting the 
+        // internal edge in the submesh (which presumably we were remeshing anyway, so changes are ok).
+        public void RepairPossibleNonManifoldEdges()
+        {
+            // [TODO] do we need to repeat this more than once? I don't think so...
+
+            // repair submesh
+            int NE = Region.SubMesh.MaxEdgeID;
+            List<int> split_edges = new List<int>();
+            for (int eid = 0; eid < NE; ++eid) {
+                if (Region.SubMesh.IsEdge(eid) == false)
+                    continue;
+                if (Region.SubMesh.IsBoundaryEdge(eid))
+                    continue;
+                Index2i edgev = Region.SubMesh.GetEdgeV(eid);
+                if (Region.SubMesh.IsBoundaryVertex(edgev.a) && Region.SubMesh.IsBoundaryVertex(edgev.b)) {
+                    // ok, we have an internal edge where both verts are on the boundary
+                    // now check if it is an edge in the base mesh
+                    int base_a = Region.MapVertexToBaseMesh(edgev.a);
+                    int base_b = Region.MapVertexToBaseMesh(edgev.b);
+                    if (base_a != DMesh3.InvalidID && base_b != DMesh3.InvalidID) {
+                        // both vertices in base mesh...right?
+                        Debug.Assert(Region.BaseMesh.IsVertex(base_a) && Region.BaseMesh.IsVertex(base_b));
+                        int base_eid = Region.BaseMesh.FindEdge(base_a, base_b);
+                        if (base_eid != DMesh3.InvalidID)
+                            split_edges.Add(eid);
+                    }
+                }
+            }
+
+            // split any problem edges we found and repeat this loop
+            for (int i = 0; i < split_edges.Count; ++i) {
+                NTMesh3.EdgeSplitInfo split_info;
+                Region.SubMesh.SplitEdge(split_edges[i], out split_info);
+            }
+        }
+
+
+        /// <summary>
+        /// set group ID for entire submesh
+        /// </summary>
+        //public void SetSubmeshGroupID(int gid)
+        //{
+        //    FaceGroupUtil.SetGroupID(Region.SubMesh, gid);
+        //}
+
+
+        // Remove the original submesh region and merge in the remeshed version.
+        // You can call this multiple times as the base-triangle-set is updated.
+        //
+        // By default, we allow the submesh to be modified to prevent creation of
+        // non-manifold edges. You can disable this, however then some of the submesh
+        // triangles may be discarded.
+        //
+        // Returns false if there were errors in insertion, ie if some triangles
+        // failed to insert. Does not revert changes that were successful.
+        public bool BackPropropagate(bool bAllowSubmeshRepairs = true)
+        {
+            if (bAllowSubmeshRepairs) {
+                RepairPossibleNonManifoldEdges();
+            }
+
+            // remove existing submesh triangles
+            var editor = new NTMeshEditor(BaseMesh);
+            editor.RemoveTriangles(cur_base_tris, true);
+
+            // insert new submesh
+            int[] new_tris = new int[Region.SubMesh.TriangleCount];
+            ReinsertSubToBaseMapV = null;
+            bool bOK = editor.ReinsertSubmesh(Region, ref new_tris, out ReinsertSubToBaseMapV, ReinsertDuplicateTriBehavior);
+
+            // reconstruct this...hacky?
+            int NT = Region.SubMesh.MaxTriangleID;
+            ReinsertSubToBaseMapT = new IndexMap(false, NT);
+            int nti = 0;
+            for (int ti = 0; ti < NT; ++ti) {
+                if (Region.SubMesh.IsTriangle(ti) == false)
+                    continue;
+                ReinsertSubToBaseMapT[ti] = new_tris[nti++];
+            }
+
+            // assert that new triangles are all valid (goes wrong sometimes??)
+            Debug.Assert(IndexUtil.IndicesCheck(new_tris, BaseMesh.IsTriangle));
+
+            cur_base_tris = new_tris;
+            return bOK;
+        }
+
+
+
+
+
+        // transfer vertex positions in submesh back to base mesh
+        public bool BackPropropagateVertices(bool bRecomputeBoundaryNormals = false)
+        {
+            bool bNormals = (Region.SubMesh.HasVertexNormals && Region.BaseMesh.HasVertexNormals);
+            foreach ( int subvid in Region.SubMesh.VertexIndices() ) {
+                int basevid = Region.SubToBaseV[subvid];
+                Vector3d v = Region.SubMesh.GetVertex(subvid);
+                Region.BaseMesh.SetVertex(basevid, v);
+                if (bNormals)
+                    Region.BaseMesh.SetVertexNormal(basevid, Region.SubMesh.GetVertexNormal(subvid));
+            }
+
+            if (bRecomputeBoundaryNormals) {
+                foreach ( int basevid in Region.BaseBorderV ) {
+                    Vector3d n = MeshNormals.QuickCompute(Region.BaseMesh, basevid);
+                    Region.BaseMesh.SetVertexNormal(basevid, (Vector3f)n);
+                }
+            }
+
+            return true;
+        }
+
+
+
+    }
+}

--- a/mesh_ops/NTRemoveOccludedTriangles.cs
+++ b/mesh_ops/NTRemoveOccludedTriangles.cs
@@ -1,0 +1,207 @@
+﻿// Copyright (c) Ryan Schmidt (rms@gradientspace.com) - All Rights Reserved
+// Distributed under the Boost Software License, Version 1.0. http://www.boost.org/LICENSE_1_0.txt
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using g4;
+
+namespace gs
+{
+	/// <summary>
+	/// Remove "occluded" triangles, ie triangles on the "inside" of the mesh. 
+    /// This is a fuzzy definition, current implementation is basically computing
+    /// something akin to ambient occlusion, and if face is fully occluded, then
+    /// we classify it as inside and remove it.
+	/// </summary>
+	public class NTRemoveOccludedTriangles
+	{
+		public NTMesh3 Mesh;
+        public NTMeshAABBTree3 Spatial;
+
+        // indices of removed triangles. List will be empty if nothing removed
+        public List<int> RemovedT = null;
+
+        // Mesh.RemoveTriange() can return false, if that happens, this will be true
+        public bool RemoveFailed = false;
+
+        // if true, then we discard tris if any vertex is occluded.
+        // Otherwise we discard based on tri centroids
+        public bool PerVertex = false;
+
+        // we nudge points out by this amount to try to counteract numerical issues
+        public double NormalOffset = MathUtil.ZeroTolerance;
+
+        // use this as winding isovalue for WindingNumber mode
+        public double WindingIsoValue = 0.5;
+
+        public enum CalculationMode
+        {
+            //RayParity = 0,
+            AnalyticWindingNumber = 1,
+            FastWindingNumber = 2,
+            SimpleOcclusionTest = 3
+        }
+        public CalculationMode InsideMode = CalculationMode.FastWindingNumber;
+
+
+        /// <summary>
+        /// Set this to be able to cancel running remesher
+        /// </summary>
+        public ProgressCancel Progress = null;
+
+        /// <summary>
+        /// if this returns true, abort computation. 
+        /// </summary>
+        protected virtual bool Cancelled() {
+            return (Progress == null) ? false : Progress.Cancelled();
+        }
+
+
+
+        public NTRemoveOccludedTriangles(NTMesh3 mesh)
+		{
+			Mesh = mesh;
+		}
+
+        public NTRemoveOccludedTriangles(NTMesh3 mesh, NTMeshAABBTree3 spatial)
+        {
+            Mesh = mesh;
+            Spatial = spatial;
+        }
+
+
+        public virtual bool Apply()
+        {
+            var testAgainstMesh = Mesh;
+            //if (InsideMode == CalculationMode.RayParity) {
+            //    MeshBoundaryLoops loops = new MeshBoundaryLoops(testAgainstMesh);
+            //    if (loops.Count > 0) {
+            //        testAgainstMesh = new NTMesh3(Mesh);
+            //        foreach (var loop in loops) {
+            //            if (Cancelled())
+            //                return false;
+            //            SimpleHoleFiller filler = new SimpleHoleFiller(testAgainstMesh, loop);
+            //            filler.Fill();
+            //        }
+            //    }
+            //}
+
+            NTMeshAABBTree3 spatial = (Spatial != null && testAgainstMesh == Mesh) ? 
+                Spatial : new NTMeshAABBTree3(testAgainstMesh, true);
+            if (InsideMode == CalculationMode.AnalyticWindingNumber)
+                spatial.WindingNumber(Vector3d.Zero);
+            else if (InsideMode == CalculationMode.FastWindingNumber )
+                spatial.FastWindingNumber(Vector3d.Zero);
+
+            if (Cancelled())
+                return false;
+
+            // ray directions
+            List<Vector3d> ray_dirs = null; int NR = 0;
+            if (InsideMode == CalculationMode.SimpleOcclusionTest) {
+                ray_dirs = new List<Vector3d>();
+                ray_dirs.Add(Vector3d.AxisX); ray_dirs.Add(-Vector3d.AxisX);
+                ray_dirs.Add(Vector3d.AxisY); ray_dirs.Add(-Vector3d.AxisY);
+                ray_dirs.Add(Vector3d.AxisZ); ray_dirs.Add(-Vector3d.AxisZ);
+                NR = ray_dirs.Count;
+            }
+
+            Func<Vector3d, bool> isOccludedF = (pt) => {
+
+                //if (InsideMode == CalculationMode.RayParity) {
+                //    return spatial.IsInside(pt);
+                //} else 
+                if (InsideMode == CalculationMode.AnalyticWindingNumber) {
+                    return spatial.WindingNumber(pt) > WindingIsoValue;
+                } else if (InsideMode == CalculationMode.FastWindingNumber) {
+                    return spatial.FastWindingNumber(pt) > WindingIsoValue;
+                } else {
+                    for (int k = 0; k < NR; ++k) {
+                        int hit_tid = spatial.FindNearestHitTriangle(new Ray3d(pt, ray_dirs[k]));
+                        if (hit_tid == DMesh3.InvalidID)
+                            return false;
+                    }
+                    return true;
+                }
+            };
+
+            bool cancel = false;
+
+            BitArray vertices = null;
+            if ( PerVertex ) {
+                vertices = new BitArray(Mesh.MaxVertexID);
+
+                MeshNormals normals = null;
+                if (Mesh.HasVertexNormals == false) {
+                    normals = new MeshNormals(Mesh);
+                    normals.Compute();
+                }
+
+                gParallel.ForEach(Mesh.VertexIndices(), (vid) => {
+                    if (cancel) return;
+                    if (vid % 10 == 0) cancel = Cancelled();
+
+                    Vector3d c = Mesh.GetVertex(vid);
+                    Vector3d n = (normals == null) ? Mesh.GetVertexNormal(vid) : normals[vid];
+                    c += n * NormalOffset;
+                    vertices[vid] = isOccludedF(c);
+                });
+            }
+            if (Cancelled())
+                return false;
+
+            RemovedT = new List<int>();
+            SpinLock removeLock = new SpinLock();
+
+            gParallel.ForEach(Mesh.TriangleIndices(), (tid) => {
+                if (cancel) return;
+                if (tid % 10 == 0) cancel = Cancelled();
+
+                bool inside = false;
+                if (PerVertex) {
+                    Index3i tri = Mesh.GetTriangle(tid);
+                    inside = vertices[tri.a] || vertices[tri.b] || vertices[tri.c];
+
+                } else {
+                    Index3i tri = Mesh.GetTriangle(tid);
+                    Vector3d n = Mesh.GetTriNormal(tid);
+
+                    var c = Mesh.GetTriCentroid(tid);
+                    var c0 = Mesh.GetVertex(tri.a);
+                    var c1 = Mesh.GetVertex(tri.b);
+                    var c2 = Mesh.GetVertex(tri.c);
+                    
+                    c += n * NormalOffset;
+                    c0 += n * NormalOffset;
+                    c1 += n * NormalOffset;
+                    c2 += n * NormalOffset;
+                    
+                    inside = isOccludedF(c) && isOccludedF(c0) && isOccludedF(c1) && isOccludedF(c2);
+                }
+
+                if (inside) {
+                    bool taken = false;
+                    removeLock.Enter(ref taken);
+                    RemovedT.Add(tid);
+                    removeLock.Exit();
+                }
+            });
+
+            if (Cancelled())
+                return false;
+
+            if (RemovedT.Count > 0)
+            {
+                var editor = new NTMeshEditor(Mesh);
+                bool bOK = editor.RemoveTriangles(RemovedT, true);
+                RemoveFailed = (bOK == false);
+            }
+
+            return true;
+		}
+
+
+        
+	}
+}

--- a/mesh_ops/NTRemoveOccludedTriangles.cs
+++ b/mesh_ops/NTRemoveOccludedTriangles.cs
@@ -37,7 +37,7 @@ namespace gs
 
         public enum CalculationMode
         {
-            //RayParity = 0,
+            RayParity = 0,
             AnalyticWindingNumber = 1,
             FastWindingNumber = 2,
             SimpleOcclusionTest = 3
@@ -109,9 +109,9 @@ namespace gs
 
             Func<Vector3d, bool> isOccludedF = (pt) => {
 
-                //if (InsideMode == CalculationMode.RayParity) {
-                //    return spatial.IsInside(pt);
-                //} else 
+                if (InsideMode == CalculationMode.RayParity) {
+                    return spatial.IsInside(pt);
+                } else 
                 if (InsideMode == CalculationMode.AnalyticWindingNumber) {
                     return spatial.WindingNumber(pt) > WindingIsoValue;
                 } else if (InsideMode == CalculationMode.FastWindingNumber) {
@@ -164,7 +164,7 @@ namespace gs
                     inside = vertices[tri.a] || vertices[tri.b] || vertices[tri.c];
 
                 } else {
-                    Index3i tri = Mesh.GetTriangle(tid);
+                    //Index3i tri = Mesh.GetTriangle(tid);
                     Vector3d n = Mesh.GetTriNormal(tid);
 
                     var c = Mesh.GetTriCentroid(tid);

--- a/mesh_ops/NTRemoveOccludedTriangles.cs
+++ b/mesh_ops/NTRemoveOccludedTriangles.cs
@@ -168,16 +168,16 @@ namespace gs
                     Vector3d n = Mesh.GetTriNormal(tid);
 
                     var c = Mesh.GetTriCentroid(tid);
-                    var c0 = Mesh.GetVertex(tri.a);
-                    var c1 = Mesh.GetVertex(tri.b);
-                    var c2 = Mesh.GetVertex(tri.c);
+                    //var c0 = Mesh.GetVertex(tri.a);
+                    //var c1 = Mesh.GetVertex(tri.b);
+                    //var c2 = Mesh.GetVertex(tri.c);
                     
                     c += n * NormalOffset;
-                    c0 += n * NormalOffset;
-                    c1 += n * NormalOffset;
-                    c2 += n * NormalOffset;
-                    
-                    inside = isOccludedF(c) && isOccludedF(c0) && isOccludedF(c1) && isOccludedF(c2);
+                    //c0 += n * NormalOffset;
+                    //c1 += n * NormalOffset;
+                    //c2 += n * NormalOffset;
+
+                    inside = isOccludedF(c); // || isOccludedF(c0) || isOccludedF(c1) || isOccludedF(c2);
                 }
 
                 if (inside) {

--- a/mesh_ops/NTSimpleHoleFiller.cs
+++ b/mesh_ops/NTSimpleHoleFiller.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace g4
+{
+    public class NTSimpleHoleFiller
+    {
+        public NTMesh3 Mesh;
+        public NTEdgeLoop Loop;
+
+        public int NewVertex;
+        public int[] NewTriangles;
+
+
+        public NTSimpleHoleFiller(NTMesh3 mesh, NTEdgeLoop loop)
+        {
+            Mesh = mesh;
+            Loop = loop;
+
+            NewVertex = DMesh3.InvalidID;
+            NewTriangles = null;
+        }
+
+
+
+        public virtual ValidationStatus Validate()
+        {
+            ValidationStatus loopStatus = MeshValidation.IsBoundaryLoop(Mesh, Loop);
+            return loopStatus;
+        }
+
+
+        public virtual bool Fill(int group_id = -1)
+        {
+            if (Loop.Vertices.Length < 3)
+                return false;
+
+            // this just needs one triangle
+            if ( Loop.Vertices.Length == 3 ) {
+                Index3i tri = new Index3i(Loop.Vertices[0], Loop.Vertices[2], Loop.Vertices[1]);
+                int new_tid = Mesh.AppendTriangle(tri, group_id);
+                if (new_tid < 0)
+                    return false;
+                NewTriangles = new int[1] { new_tid };
+                NewVertex = DMesh3.InvalidID;
+                return true;
+            }
+
+            // [TODO] 4-case? could check nbr normals to figure out best internal edge...
+
+
+            // compute centroid
+            Vector3d c = Vector3d.Zero;
+            for (int i = 0; i < Loop.Vertices.Length; ++i)
+                c += Mesh.GetVertex(Loop.Vertices[i]);
+            c *= 1.0 / Loop.Vertices.Length;
+
+            // add centroid vtx
+            NewVertex = Mesh.AppendVertex(c);
+
+            // stitch triangles
+            var editor = new NTMeshEditor(Mesh);
+            try {
+                NewTriangles = editor.AddTriangleFan_OrderedVertexLoop(NewVertex, Loop.Vertices, group_id);
+            } catch {
+                NewTriangles = null;
+            }
+
+            // if fill failed, back out vertex-add
+            if ( NewTriangles == null ) {
+                Mesh.RemoveVertex(NewVertex, true, false);
+                NewVertex = DMesh3.InvalidID;
+				return false;
+            } else 
+            	return true;
+
+        }
+
+
+    }
+}

--- a/mesh_selection/NTMeshBoundaryLoops.cs
+++ b/mesh_selection/NTMeshBoundaryLoops.cs
@@ -219,10 +219,6 @@ namespace g4
                             int num_be = Mesh.VtxAllBoundaryEdges(cure_b, all_e);
                             num_be = BufferUtil.CountValid(all_e, EdgeFilterF, num_be);
                         }
-						//} else {
-						//	if (EdgeFilterF(e0) == false) bdry_nbrs--;
-						//	if (EdgeFilterF(e1) == false) bdry_nbrs--;
-						//}
 					}
 
 

--- a/mesh_selection/NTMeshBoundaryLoops.cs
+++ b/mesh_selection/NTMeshBoundaryLoops.cs
@@ -1,0 +1,635 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Diagnostics;
+
+namespace g4
+{
+	public class NTMeshBoundaryLoopsException : Exception
+	{
+		public NTMeshBoundaryLoopsException(string message) : base(message) {}
+		public bool UnclosedLoop = false;
+		public bool BowtieFailure = false;
+        public bool RepeatedEdge = false;
+	}
+
+	/// <summary>
+	/// Extract boundary EdgeLoops from Mesh. Can also extract EdgeSpans for open areas,
+    /// however default behavior is to ignore these. Set .SpanBehavior to configure.
+	/// </summary>
+    public class NTMeshBoundaryLoops : IEnumerable<NTEdgeLoop>
+    {
+        public NTMesh3 Mesh;
+        public List<NTEdgeLoop> Loops;
+
+        public List<NTEdgeSpan> Spans;       // spans are unclosed loops
+        public bool SawOpenSpans = false;  // will be set to true if we find any open spans
+        public bool FellBackToSpansOnFailure = false;       // set to true if we had to add spans to recover from failure
+                                                            // currently this happens if we cannot extract simple loops from a loop with bowties
+
+        // What should we do if we encounter open spans. Mainly a result of EdgeFilter, but can also
+        // happen on meshes w/ crazy bowties
+        public enum SpanBehaviors
+        {
+            Ignore, ThrowException, Compute
+        };
+        public SpanBehaviors SpanBehavior = SpanBehaviors.Compute;
+
+        // What should we do if we encounter an unrecoverable failure while walking a loop
+        public enum FailureBehaviors
+        {
+            ThrowException,       // die, and you clean up
+            ConvertToOpenSpan     // keep un-closed loop as a span
+        }
+        public FailureBehaviors FailureBehavior = FailureBehaviors.ConvertToOpenSpan;
+
+        // if enabled, only edges where this returns true are considered
+        public Func<int, bool> EdgeFilterF = null;
+
+        // if we throw an exception, we will try to set FailureBowties, so that client
+        // can try repairing these vertices
+        public List<int> FailureBowties = null;
+
+
+        public NTMeshBoundaryLoops(NTMesh3 mesh, bool bAutoCompute = true)
+        {
+            this.Mesh = mesh;
+			if (bAutoCompute)
+           		Compute();
+        }
+
+        public int Count {
+            get { return Loops.Count; }
+        }
+        public int SpanCount {
+            get { return Spans.Count; }
+        }
+
+        public NTEdgeLoop this[int index] {
+            get { return Loops[index]; }
+        }
+
+        public IEnumerator<NTEdgeLoop> GetEnumerator() {
+            return Loops.GetEnumerator();
+        }
+        IEnumerator IEnumerable.GetEnumerator() {
+            return Loops.GetEnumerator();
+        }
+
+
+        /// <summary>
+        /// Index of Loop with largest vertex count
+        /// </summary>
+        public int MaxVerticesLoopIndex {
+            get {
+                int j = 0;
+                for (int i = 1; i < Loops.Count; ++i) {
+                    if (Loops[i].Vertices.Length > Loops[j].Vertices.Length)
+                        j = i;
+                }
+                return j;
+            }
+        }
+
+
+        /// <summary>
+        /// find pair (loop_index,in_loop_index) of vertex vID in EdgeLoops, or Index2i.Max if not found
+        /// </summary>
+        public Index2i FindVertexIndex(int vID)
+        {
+            int N = Loops.Count;
+            for (int li = 0; li < N; ++li) {
+                int idx = Loops[li].FindVertexIndex(vID);
+                if (idx >= 0)
+                    return new Index2i(li, idx);
+            }
+            return Index2i.Max;
+        }
+
+
+
+        /// <summary>
+        /// find the loop index that contains a vertex, or return -1
+        /// </summary>
+        public int FindLoopContainingVertex(int vid)
+        {
+            int N = Loops.Count;
+            for (int li = 0; li < N; ++li) {
+                if (Loops[li].Vertices.Contains(vid))
+                    return li;
+            }
+            return -1;
+        }
+
+
+        /// <summary>
+        /// find the loop index that contains an edge, or return -1
+        /// </summary>
+        public int FindLoopContainingEdge(int eid)
+        {
+            int N = Loops.Count;
+            for (int li = 0; li < N; ++li) {
+                if (Loops[li].Edges.Contains(eid))
+                    return li;
+            }
+            return -1;
+        }
+
+
+
+		/// <summary>
+		/// Find the set of boundary EdgeLoops. Note that if we encounter topological
+		/// issues, we will throw MeshBoundaryLoopsException w/ more info (if possible)
+		/// </summary>
+		public bool Compute()
+        {
+			// This algorithm assumes that triangles are oriented consistently, 
+			// so closed boundary-loop can be followed by walking edges in-order
+
+			Loops = new List<NTEdgeLoop>();
+            Spans = new List<NTEdgeSpan>();
+
+            // early-out if we don't actually have boundaries
+            if (Mesh.CachedIsClosed)
+                return true;
+
+            int NE = Mesh.MaxEdgeID;
+
+            // Temporary memory used to indicate when we have "used" an edge.
+            BitArray used_edge = new BitArray(NE);
+            used_edge.SetAll(false);
+
+            // current loop is stored here, cleared after each loop extracted
+            List<int> loop_edges = new List<int>();     // [RMS] not sure we need this...
+            List<int> loop_verts = new List<int>();
+            List<int> bowties = new List<int>();
+
+            // Temp buffer for reading back all boundary edges of a vertex.
+            // probably always small but in pathological cases it could be large...
+            int[] all_e = new int[16];
+
+            // [TODO] might make sense to precompute some things here, like num_be for each bdry vtx?
+
+            // process all edges of mesh
+            for ( int eid = 0; eid < NE; ++eid ) {
+                if (!Mesh.IsEdge(eid))
+                    continue;
+                if ( used_edge[eid] == true )
+                    continue;
+                if (Mesh.IsBoundaryEdge(eid) == false)
+                    continue;
+
+				if (EdgeFilterF != null && EdgeFilterF(eid) == false) {
+					used_edge[eid] = true;
+					continue;
+				}
+
+                // ok this is start of a boundary chain
+                int eStart = eid;
+                used_edge[eStart] = true;
+                loop_edges.Add(eStart);
+
+                int eCur = eid;
+
+                // follow the chain in order of oriented edges
+                bool bClosed = false;
+                bool bIsOpenSpan = false;
+                while ( ! bClosed ) {
+                    Index2i ev = Mesh.GetOrientedBoundaryEdgeV(eCur);
+                    int cure_a = ev.a, cure_b = ev.b;
+                    if (bIsOpenSpan) {
+                        cure_a = ev.b; cure_b = ev.a;
+                    } else {
+                        loop_verts.Add(cure_a);
+                    }
+
+                    //int e0 = -1, e1 = 1;
+                    var bdry_nbrs = Mesh.VtxBoundaryEdges(cure_b);
+                    var e0 = bdry_nbrs.Count > 0 ? bdry_nbrs[0] : 1;
+                    var e1 = bdry_nbrs.Count > 1 ? bdry_nbrs[1] : 1;
+
+                    // have to filter this list, if we are filtering. this is ugly.
+                    if (EdgeFilterF != null) {
+                        if (bdry_nbrs.Count > 2)
+                        {
+                            if (bdry_nbrs.Count >= all_e.Length)
+                                all_e = new int[bdry_nbrs.Count];
+                            // we may repreat this below...irritating...
+                            int num_be = Mesh.VtxAllBoundaryEdges(cure_b, all_e);
+                            num_be = BufferUtil.CountValid(all_e, EdgeFilterF, num_be);
+                        }
+						//} else {
+						//	if (EdgeFilterF(e0) == false) bdry_nbrs--;
+						//	if (EdgeFilterF(e1) == false) bdry_nbrs--;
+						//}
+					}
+
+
+                    if (bdry_nbrs.Count < 2) {   // hit an 'endpoint' vertex (should only happen when Filter is on...)
+                        if ( SpanBehavior == SpanBehaviors.ThrowException )
+                            throw new MeshBoundaryLoopsException("MeshBoundaryLoops.Compute: found open span at vertex " + cure_b) { UnclosedLoop = true };
+                        if (bIsOpenSpan) {
+                            bClosed = true;
+                            continue;
+                        } else {
+                            bIsOpenSpan = true;    // begin open span
+                            eCur = loop_edges[0];  // restart at other end of loop
+                            loop_edges.Reverse();  // do this so we can push to front
+                            continue;
+                        }
+                    }
+
+                    int eNext = -1;
+
+                    if (bdry_nbrs.Count > 2) {
+						// found "bowtie" vertex...things just got complicated!
+
+						if (cure_b == loop_verts[0]) {
+							// The "end" of the current edge is the same as the start vertex.
+							// This means we can close the loop here. Might as well!
+							eNext = -2;   // sentinel value used below
+
+						} else {
+							// try to find an unused outgoing edge that is oriented properly.
+							// This could create sub-loops, we will handle those later
+							if (bdry_nbrs.Count >= all_e.Length)
+								all_e = new int[2*bdry_nbrs.Count];
+							int num_be = Mesh.VtxAllBoundaryEdges(cure_b, all_e);
+                            Debug.Assert(num_be == bdry_nbrs.Count);
+
+                            if (EdgeFilterF != null) {
+								num_be = BufferUtil.FilterInPlace(all_e, EdgeFilterF, num_be);
+							}
+
+							// Try to pick the best "turn left" vertex.
+							eNext = find_left_turn_edge(eCur, cure_b, all_e, num_be, used_edge);
+                            if ( eNext == -1 ) {
+                                if ( FailureBehavior == FailureBehaviors.ThrowException || SpanBehavior == SpanBehaviors.ThrowException)
+                                    throw new MeshBoundaryLoopsException("MeshBoundaryLoops.Compute: cannot find valid outgoing edge at bowtie vertex " + cure_b) { BowtieFailure = true };
+                                
+                                // ok, we are stuck. all we can do now is terminate this loop and keep it as a span
+                                if (bIsOpenSpan) {
+                                    bClosed = true;
+                                } else {
+                                    bIsOpenSpan = true;
+                                    bClosed = true;
+                                }
+                                continue;
+                            }
+                        }
+
+                        if ( bowties.Contains(cure_b) == false )
+                            bowties.Add(cure_b);
+
+                    } else {
+                        // walk forward to next available edge
+                        Debug.Assert(e0 == eCur || e1 == eCur);
+                        eNext = (e0 == eCur) ? e1 : e0;
+                    }
+
+                    if (eNext == -2) {
+                        // found a bowtie vert that is the same as start-of-loop, so we
+                        // are just closing it off explicitly
+                        bClosed = true;
+                    } else if (eNext == eStart) {
+                        // found edge at start of loop, so loop is done.
+                        bClosed = true;
+                    } else if ( used_edge[eNext] != false ) {
+                        // disaster case - the next edge is already used, but it is not the start of our loop
+                        // All we can do is convert to open span and terminate
+                        if (FailureBehavior == FailureBehaviors.ThrowException || SpanBehavior == SpanBehaviors.ThrowException)
+                            throw new MeshBoundaryLoopsException("MeshBoundaryLoops.Compute: encountered repeated edge " + eNext) { RepeatedEdge = true };
+                        bIsOpenSpan = true;
+                        bClosed = true;
+
+                    } else {
+                        // push onto accumulated list
+                        Debug.Assert( used_edge[eNext] == false );
+                        loop_edges.Add(eNext);
+                        used_edge[eNext] = true;
+                        eCur = eNext;
+                    }
+                }
+
+                if (bIsOpenSpan) {
+                    SawOpenSpans = true;
+                    if (SpanBehavior == SpanBehaviors.Compute) {
+                        loop_edges.Reverse();  // orient properly
+                        var span = NTEdgeSpan.FromEdges(Mesh, loop_edges);
+                        Spans.Add(span);
+                    }
+                } else if (bowties.Count > 0) {
+                    // if we saw a bowtie vertex, we might need to break up this loop,
+                    // so call extract_subloops
+                    Subloops subloops = extract_subloops(loop_verts, loop_edges, bowties);
+                    foreach ( var loop in subloops.Loops )
+                        Loops.Add(loop);
+                    if ( subloops.Spans.Count > 0 ) {
+                        FellBackToSpansOnFailure = true;
+                        foreach (var span in subloops.Spans)
+                            Spans.Add(span);
+                    }
+                } else {
+                    // clean simple loop, convert to EdgeLoop instance
+                    var loop = new NTEdgeLoop(Mesh);
+                    loop.Vertices = loop_verts.ToArray();
+                    loop.Edges = loop_edges.ToArray();
+                    Loops.Add(loop);
+                }
+
+                // reset these lists
+                loop_edges.Clear();
+                loop_verts.Clear();
+                bowties.Clear();
+            }
+
+            return true;
+        }
+
+
+
+
+        // [TODO] cache this in a dictionary? we will not need very many, but we will
+        //   need each multiple times!
+        Vector3d get_vtx_normal(int vid)
+        {
+            Vector3d n = Vector3d.Zero;
+            foreach (int ti in Mesh.VtxTrianglesItr(vid))
+                n += Mesh.GetTriNormal(ti);
+            n.Normalize();
+            return n;
+        }
+
+
+
+        // ok, bdry_edges[0...bdry_edges_count] contains the boundary edges coming out of bowtie_v.
+        // We want to pick the best one to continue the loop that came in to bowtie_v on incoming_e.
+        // If the loops are all sane, then we will get the smallest loops by "turning left" at bowtie_v.
+        // So, we compute the tangent plane at bowtie_v, and then the signed angle for each
+        // viable edge in this plane. 
+        //
+        // [TODO] handle degenerate edges. what do we do then? Currently will only chose
+        //  degenerate edge if there are no other options (I think...)
+        int find_left_turn_edge(int incoming_e, int bowtie_v, int[] bdry_edges, int bdry_edges_count, BitArray used_edges  )
+        {
+            // compute normal and edge [a,bowtie]
+            Vector3d n = get_vtx_normal(bowtie_v);
+            int other_v = Mesh.edge_other_v(incoming_e, bowtie_v);
+            Vector3d ab = Mesh.GetVertex(bowtie_v) - Mesh.GetVertex(other_v);
+ 
+            // our winner
+            int best_e = -1;
+            double best_angle = double.MaxValue;
+
+            for (int i = 0; i < bdry_edges_count; ++i) {
+                int bdry_eid = bdry_edges[i];
+                if ( used_edges[bdry_eid] == true )
+                    continue;       // this edge is already used
+                Index2i bdry_ev = Mesh.GetOrientedBoundaryEdgeV(bdry_eid);
+                if (bdry_ev.a != bowtie_v)
+                    continue;       // have to be able to chain to end of current edge, orientation-wise
+
+                // compute projected angle
+                Vector3d bc = Mesh.GetVertex(bdry_ev.b) - Mesh.GetVertex(bowtie_v);
+                float fAngleS = MathUtil.PlaneAngleSignedD((Vector3f)ab, (Vector3f)bc, (Vector3f)n);
+
+                // turn left!
+                if ( best_angle == double.MaxValue || fAngleS < best_angle ) {
+                    best_angle = fAngleS;
+                    best_e = bdry_eid;
+                }
+            }
+
+            // [RMS] w/ bowtie vertices and open spans, this does happen
+            //Debug.Assert(best_e != -1);
+
+            return best_e;
+        }
+
+
+
+        struct Subloops
+        {
+            public List<NTEdgeLoop> Loops;
+            public List<NTEdgeSpan> Spans;
+        }
+
+
+        // This is called when loopV contains one or more "bowtie" vertices.
+        // These vertices *might* be duplicated in loopV (but not necessarily)
+        // If they are, we have to break loopV into subloops that don't contain duplicates.
+        //
+        // The list bowties contains all the possible duplicates 
+        // (all v in bowties occur in loopV at least once)
+        //
+        // Currently loopE is not used, and the returned EdgeLoop objects do not have their Edges
+        // arrays initialized. Perhaps to improve in future.
+        //
+        // An unhandled case to think about is where we have a sequence [..A..B..A..B..] where
+        // A and B are bowties. In this case there are no A->A or B->B subloops. What should
+        // we do here??
+        Subloops extract_subloops(List<int> loopV, List<int> loopE, List<int> bowties )
+        {
+            Subloops subs = new Subloops();
+            subs.Loops = new List<NTEdgeLoop>(); subs.Spans = new List<NTEdgeSpan>();
+
+            // figure out which bowties we saw are actually duplicated in loopV
+            List<int> dupes = new List<int>();
+            foreach ( int bv in bowties ) {
+                if (count_in_list(loopV, bv) > 1)
+                    dupes.Add(bv);
+            }
+
+            // we might not actually have any duplicates, if we got luck. Early out in that case
+            if ( dupes.Count == 0 ) {
+                subs.Loops.Add(new NTEdgeLoop(Mesh) {
+                    Vertices = loopV.ToArray(), Edges = loopE.ToArray(), BowtieVertices = bowties.ToArray()
+                });
+                return subs;
+            }
+
+            // This loop extracts subloops until we have dealt with all the
+            // duplicate vertices in loopV
+            while ( dupes.Count > 0 ) {
+
+                // Find shortest "simple" loop, ie a loop from a bowtie to itself that
+                // does not contain any other bowties. This is an independent loop.
+                // We're doing a lot of extra work here if we only have one element in dupes...
+                int bi = 0, bv = 0;
+                int start_i = -1, end_i = -1;
+                int bv_shortest = -1; int shortest = int.MaxValue;
+                for ( ; bi < dupes.Count; ++bi ) {
+                    bv = dupes[bi];
+                    if (is_simple_bowtie_loop(loopV, dupes, bv, out start_i, out end_i)) {
+                        int len = count_span(loopV, start_i, end_i);
+                        if (len < shortest) {
+                            bv_shortest = bv;
+                            shortest = len;
+                        }
+                    }
+                }
+
+                // failed to find a simple loop. Not sure what to do in this situation. 
+                // If we don't want to throw, all we can do is convert the remaining 
+                // loop to a span and return. 
+                // (Or should we keep it as a loop and set flag??)
+                if (bv_shortest == -1) {
+                    if (FailureBehavior == FailureBehaviors.ThrowException) {
+                        FailureBowties = dupes;
+                        throw new MeshBoundaryLoopsException("MeshBoundaryLoops.Compute: Cannot find a valid simple loop");
+                    }
+                    var span = new NTEdgeSpan(Mesh);
+                    List<int> verts = new List<int>();
+                    for (int i = 0; i < loopV.Count; ++i) {
+                        if (loopV[i] != -1)
+                            verts.Add(loopV[i]);
+                    }
+                    span.Vertices = verts.ToArray();
+                    span.Edges = NTEdgeSpan.VerticesToEdges(Mesh, span.Vertices);
+                    span.BowtieVertices = bowties.ToArray();
+                    subs.Spans.Add(span);
+                    return subs;
+                }
+
+                if (bv != bv_shortest) {
+                    bv = bv_shortest;
+                    // running again just to get start_i and end_i...
+                    is_simple_bowtie_loop(loopV, dupes, bv, out start_i, out end_i);
+                }
+
+                Debug.Assert(loopV[start_i] == bv && loopV[end_i] == bv );
+
+                var loop = new NTEdgeLoop(Mesh);
+                loop.Vertices = extract_span(loopV, start_i, end_i, true);
+                loop.Edges = NTEdgeLoop.VertexLoopToEdgeLoop(Mesh, loop.Vertices);
+                loop.BowtieVertices = bowties.ToArray();
+                subs.Loops.Add(loop);
+
+                // If there are no more duplicates of this bowtie, we can treat
+                // it like a regular vertex now
+                if (count_in_list(loopV, bv) < 2)
+                    dupes.Remove(bv);
+            }
+
+            // Should have one loop left that contains duplicates. 
+            // Extract this as a separate loop
+            int nLeft = 0;
+            for ( int i = 0; i < loopV.Count; ++i ) {
+                if (loopV[i] != -1)
+                    nLeft++;
+            }
+            if (nLeft > 0) {
+                var loop = new NTEdgeLoop(Mesh);
+                loop.Vertices = new int[nLeft];
+                int vi = 0;
+                for (int i = 0; i < loopV.Count; ++i) {
+                    if (loopV[i] != -1)
+                        loop.Vertices[vi++] = loopV[i];
+                }
+                loop.Edges = NTEdgeLoop.VertexLoopToEdgeLoop(Mesh, loop.Vertices);
+                loop.BowtieVertices = bowties.ToArray();
+                subs.Loops.Add(loop);
+            }
+
+            return subs;
+        }
+
+
+
+        /*
+         * In all the functions below, the list loopV is assumed to possibly
+         * contain "removed" vertices indicated by -1. These are ignored.
+         */
+
+    
+        // Check if the loop from bowtieV to bowtieV inside loopV contains any other bowtie verts.
+        // Also returns start and end indices in loopV of "clean" loop
+        // Note that start may be < end, if the "clean" loop wraps around the end
+        bool is_simple_bowtie_loop(List<int> loopV, List<int> bowties, int bowtieV, out int start_i, out int end_i)
+        {
+            // find two indices of bowtie vert
+            start_i = find_index(loopV, 0, bowtieV);
+            end_i = find_index(loopV, start_i + 1, bowtieV);
+
+            if (is_simple_path(loopV, bowties, bowtieV, start_i, end_i)) {
+                return true;
+
+            } else if (is_simple_path(loopV, bowties, bowtieV, end_i, start_i)) {
+                int tmp = start_i; start_i = end_i; end_i = tmp;
+                return true;
+
+            } else 
+                return false;       // not a simple bowtie loop!
+        }
+        
+
+        // check if forward path from loopV[i1] to loopV[i2] contains any bowtie verts other than bowtieV
+        bool is_simple_path(List<int> loopV, List<int> bowties, int bowtieV, int i1, int i2)
+        {
+            int N = loopV.Count;
+            for ( int i = i1; i != i2; i = (i+1)%N ) {
+                int vi = loopV[i];
+                if (vi == -1)
+                    continue;       // skip removed vertices
+                if (vi != bowtieV && bowties.Contains(vi))
+                    return false;
+            }
+            return true;
+        }
+
+
+        // Read out the span from loop[i0] to loop [i1-1] into an array.
+        // If bMarkInvalid, then these values are set to -1 in loop
+        int[] extract_span(List<int> loop, int i0, int i1, bool bMarkInvalid)
+        {
+            int num = count_span(loop, i0, i1);
+            int[] a = new int[num];
+            int ai = 0;
+            int N = loop.Count;
+            for (int i = i0; i != i1; i = (i + 1) % N) {
+                if (loop[i] != -1) {
+                    a[ai++] = loop[i];
+                    if (bMarkInvalid)
+                        loop[i] = -1;
+                }
+            }
+            return a;
+        }
+
+        // count number of valid vertices in l between loop[i0] and loop[i1-1]
+        int count_span(List<int> l, int i0, int i1)
+        {
+            int c = 0;
+            int N = l.Count;
+            for (int i = i0; i != i1; i = (i + 1) % N) {
+                if (l[i] != -1)
+                    c++;
+            }
+            return c;
+        }
+
+        // find the index of item in loop, starting at start index
+        int find_index(List<int> loop, int start, int item)
+        {
+            for (int i = start; i < loop.Count; ++i)
+                if (loop[i] == item)
+                    return i;
+            return -1;
+        }
+        
+        // count number of times item appears in loop
+        int count_in_list(List<int> loop, int item) {
+            int c = 0;
+            for (int i = 0; i < loop.Count; ++i)
+                if (loop[i] == item)
+                    c++;
+            return c;
+        }            
+
+    }
+
+
+
+
+}

--- a/mesh_selection/NTMeshConnectedComponents.cs
+++ b/mesh_selection/NTMeshConnectedComponents.cs
@@ -1,0 +1,254 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace g4
+{
+    public class NTMeshConnectedComponents : IEnumerable<NTMeshConnectedComponents.Component>
+    {
+        public NTMesh3 Mesh;
+
+        // if a Filter is set, only triangles contained in Filter are
+        // considered. Both filters will be applied if available.
+        public IEnumerable<int> FilterSet = null;
+        public Func<int, bool> FilterF = null;
+
+        // filter on seed values for region-growing. This can be useful
+        // to restrict components to certain areas, when you don't want
+        // (or don't know) a full-triangle-set filter
+        public Func<int, bool> SeedFilterF = null;
+
+        public struct Component
+        {
+            public int[] Indices;
+        }
+
+        public List<Component> Components;
+
+
+        public NTMeshConnectedComponents(NTMesh3 mesh)
+        {
+            Mesh = mesh;
+            Components = new List<Component>();
+        }
+
+
+        public int Count
+        {
+            get { return Components.Count; }
+        }
+
+        public Component this[int index] {
+            get { return Components[index]; }
+        }
+
+
+        public IEnumerator<Component> GetEnumerator() {
+            return Components.GetEnumerator();
+        }
+        IEnumerator IEnumerable.GetEnumerator() {
+            return Components.GetEnumerator();
+        }
+
+
+        public int LargestByCount
+        {
+            get {
+                int largest_i = 0;
+                int largest_count = Components[largest_i].Indices.Length;
+                for ( int i = 1; i < Components.Count; ++i ) {
+                    if ( Components[i].Indices.Length > largest_count ) {
+                        largest_count = Components[i].Indices.Length;
+                        largest_i = i;
+                    }
+                }
+                return largest_i;
+            }
+        }
+
+
+        public void SortByCount(bool bIncreasing = true)
+        {
+            if ( bIncreasing ) 
+                Components.Sort((x, y) => { return x.Indices.Length.CompareTo(y.Indices.Length); });
+            else
+                Components.Sort((x, y) => { return -x.Indices.Length.CompareTo(y.Indices.Length); });
+        }
+
+
+
+        /// <summary>
+        /// Evaluate valueF for each component and sort by that
+        /// </summary>
+        public void SortByValue(Func<Component,double> valueF, bool bIncreasing = true)
+        {
+            Dictionary<Component, double> vals = new Dictionary<Component, double>();
+            foreach (Component c in Components)
+                vals[c] = valueF(c);
+
+            if (bIncreasing)
+                Components.Sort((x, y) => { return vals[x].CompareTo(vals[y]); });
+            else
+                Components.Sort((x, y) => { return -vals[x].CompareTo(vals[y]); });
+        }
+
+
+
+        public void FindConnectedT()
+        {
+            Components = new List<Component>();
+
+            int NT = Mesh.MaxTriangleID;
+
+            // [TODO] could use Euler formula to determine if mesh is closed genus-0...
+
+            Func<int, bool> filter_func = (i) => { return Mesh.IsTriangle(i); };
+            if (FilterF != null)
+                filter_func = (i) => { return Mesh.IsTriangle(i) && FilterF(i); };
+
+
+
+            // initial active set contains all valid triangles
+            byte[] active = new byte[Mesh.MaxTriangleID];
+            Interval1i activeRange = Interval1i.Empty;
+            if (FilterSet != null) {
+                for (int i = 0; i < NT; ++i)
+                    active[i] = 255;
+                foreach (int tid in FilterSet) {
+                    bool bValid = filter_func(tid);
+                    if (bValid) {
+                        active[tid] = 0;
+                        activeRange.Contain(tid);
+                    }
+                }
+            } else {
+                for (int i = 0; i < NT; ++i) {
+                    bool bValid = filter_func(i);
+                    if (bValid) {
+                        active[i] = 0;
+                        activeRange.Contain(i);
+                    } else {
+                        active[i] = 255;
+                    }
+                }
+            }
+
+            // temporary buffers
+            List<int> queue = new List<int>(NT / 10);
+            List<int> cur_comp = new List<int>(NT / 10);
+
+            // keep finding valid seed triangles and growing connected components
+            // until we are done
+            IEnumerable<int> range = (FilterSet != null) ? FilterSet : activeRange;
+            foreach ( int i in range ) { 
+            //for ( int i = 0; i < NT; ++i ) { 
+                if (active[i] == 255)
+                    continue;
+
+                int seed_t = i;
+                if (SeedFilterF != null && SeedFilterF(seed_t) == false)
+                    continue;
+
+                queue.Add(seed_t);
+                active[seed_t] = 1;      // in queue
+
+                while ( queue.Count > 0 ) {
+                    int cur_t = queue[queue.Count - 1];
+                    queue.RemoveAt(queue.Count - 1);
+
+                    active[cur_t] = 2;   // tri has been processed
+                    cur_comp.Add(cur_t);
+
+                    var nbrs = Mesh.TriTrianglesItr(cur_t).ToList();
+                    foreach (var nbr_t in nbrs) {
+                        if ( nbr_t != NTMesh3.InvalidID && active[nbr_t] == 0 ) {
+                            queue.Add(nbr_t);
+                            active[nbr_t] = 1;           // in queue
+                        }
+                    }
+                }
+
+
+                Component comp = new Component() {
+                    Indices = cur_comp.ToArray()
+                };
+                Components.Add(comp);
+
+                // remove tris in this component from active set
+                for ( int j = 0; j < comp.Indices.Length; ++j) {
+                    active[comp.Indices[j]] = 255;
+                }
+
+                cur_comp.Clear();
+                queue.Clear();
+            }
+
+
+        }
+
+
+
+
+        /// <summary>
+        /// Separate input mesh into disconnected shells.
+        /// Resulting array is sorted by decreasing triangle count.
+        /// </summary>
+        public static NTMesh3[] Separate(NTMesh3 meshIn)
+        {
+            var c = new NTMeshConnectedComponents(meshIn);
+            c.FindConnectedT();
+            c.SortByCount(false);
+
+            var result = new NTMesh3[c.Components.Count];
+
+            int ri = 0;
+            foreach (Component comp in c.Components) {
+                var submesh = new NTSubmesh3(meshIn, comp.Indices);
+                result[ri++] = submesh.SubMesh;
+            }
+
+            return result;
+        }
+
+
+        /// <summary>
+        /// extract largest shell of meshIn
+        /// </summary>
+        public static NTMesh3 LargestT(NTMesh3 meshIn)
+        {
+            var c = new NTMeshConnectedComponents(meshIn);
+            c.FindConnectedT();
+            c.SortByCount(false);
+            var submesh = new NTSubmesh3(meshIn, c.Components[0].Indices);
+            return submesh.SubMesh;
+        }
+
+
+
+
+        /// <summary>
+        /// Utility function that finds set of triangles connected to tSeed. Does not use MeshConnectedComponents class.
+        /// </summary>
+        public static HashSet<int> FindConnectedT(NTMesh3 mesh, int tSeed)
+        {
+            HashSet<int> found = new HashSet<int>();
+            found.Add(tSeed);
+            List<int> queue = new List<int>(64) { tSeed };
+            while ( queue.Count > 0 ) {
+                int tid = queue[queue.Count - 1];
+                queue.RemoveAt(queue.Count - 1);
+                var nbrs = mesh.TriTrianglesItr(tid);
+                foreach (var nbrid in nbrs) {
+                    if (nbrid == NTMesh3.InvalidID || found.Contains(nbrid))
+                        continue;
+                    found.Add(nbrid);
+                    queue.Add(nbrid);
+                }
+            }
+            return found;
+        }
+
+
+    }
+}

--- a/queries/MeshValidation.cs
+++ b/queries/MeshValidation.cs
@@ -45,6 +45,24 @@ namespace g4
             return ValidationStatus.Ok;
         }
 
+        public static ValidationStatus IsEdgeLoop(NTMesh3 mesh, EdgeLoop loop)
+        {
+           int N = loop.Vertices.Length;
+            for ( int i = 0; i < N; ++i ) {
+                if ( ! mesh.IsVertex(loop.Vertices[i]) )
+                    return ValidationStatus.NotAVertex;
+            }
+            for (int i = 0; i < N; ++i) {
+                int a = loop.Vertices[i];
+                int b = loop.Vertices[(i + 1) % N];
+
+                int eid = mesh.FindEdge(a, b);
+                if (eid == DMesh3.InvalidID)
+                    return ValidationStatus.VerticesNotConnectedByEdge;
+            }
+            return ValidationStatus.Ok;
+        }
+
 
 
         public static ValidationStatus IsBoundaryLoop(DMesh3 mesh, EdgeLoop loop)
@@ -74,8 +92,33 @@ namespace g4
 
             return ValidationStatus.Ok;
         }
+        public static ValidationStatus IsBoundaryLoop(NTMesh3 mesh, EdgeLoop loop)
+        {
+            int N = loop.Vertices.Length;
 
+            for ( int i = 0; i < N; ++i ) {
+                if ( ! mesh.IsBoundaryVertex(loop.Vertices[i]) )
+                    return ValidationStatus.NotBoundaryVertex;
+            }
 
+            for ( int i = 0; i < N; ++i ) {
+                int a = loop.Vertices[i];
+                int b = loop.Vertices[(i + 1) % N];
+
+                int eid = mesh.FindEdge(a, b);
+                if (eid == DMesh3.InvalidID)
+                    return ValidationStatus.VerticesNotConnectedByEdge;
+
+                if (mesh.IsBoundaryEdge(eid) == false)
+                    return ValidationStatus.NotBoundaryEdge;
+
+                Index2i ev = mesh.GetOrientedBoundaryEdgeV(eid);
+                if (!(ev.a == a && ev.b == b))
+                    return ValidationStatus.IncorrectLoopOrientation;
+            }
+
+            return ValidationStatus.Ok;
+        }
 
         public static ValidationStatus HasDuplicateTriangles(DMesh3 mesh)
         {
@@ -87,7 +130,5 @@ namespace g4
 
             return ValidationStatus.Ok;
         }
-
-
     }
 }

--- a/queries/MeshValidation.cs
+++ b/queries/MeshValidation.cs
@@ -92,7 +92,7 @@ namespace g4
 
             return ValidationStatus.Ok;
         }
-        public static ValidationStatus IsBoundaryLoop(NTMesh3 mesh, EdgeLoop loop)
+        public static ValidationStatus IsBoundaryLoop(NTMesh3 mesh, NTEdgeLoop loop)
         {
             int N = loop.Vertices.Length;
 

--- a/spatial/DMeshAABBTree.cs
+++ b/spatial/DMeshAABBTree.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 namespace g4
 {
@@ -1053,6 +1054,161 @@ namespace g4
 
             return result;
         }
+
+        /// <summary>
+        /// Compute all self-intersections of a mesh. 
+        /// TransformF argument transforms vertices of otherTree to our tree (can be null if in same coord space)
+        /// Returns pairs of intersecting triangles, which could intersect in either point or segment
+        /// </summary>
+        public virtual IntersectionsTrianglesQueryResult FindAllSelfIntersectionsTriangles(Func<Vector3d, Vector3d> TransformF = null)
+        {
+            if (mesh_timestamp != mesh.ShapeTimestamp)
+                throw new Exception("DMeshAABBTree3.FindIntersections: mesh has been modified since tree construction");
+
+            var result = new IntersectionsTrianglesQueryResult
+            {
+                TrianglePairs = new List<(int, int)>()
+            };
+
+            var intr = new IntrTriangle3Triangle3(new Triangle3d(), new Triangle3d());
+            find_self_intersection_triangles(root_index, TransformF, root_index, 0, intr, result);
+
+            return result;
+        }
+
+        protected void find_self_intersection_triangles(int iBox, Func<Vector3d, Vector3d> TransformF,
+                                  int oBox, int depth,
+                                  IntrTriangle3Triangle3 intr, IntersectionsTrianglesQueryResult result)
+        {
+            int idx = box_to_index[iBox];
+            int odx = box_to_index[oBox];
+
+            if (idx < triangles_end && odx < triangles_end)
+            {
+                // ok we are at triangles for both trees, do triangle-level testing
+                Triangle3d tri = new Triangle3d(), otri = new Triangle3d();
+                int num_tris = index_list[idx], onum_tris = index_list[odx];
+
+                // outer iteration is "other" tris that need to be transformed (more expensive)
+                for (int j = 1; j <= onum_tris; ++j)
+                {
+                    int tj = index_list[odx + j];
+                    if (TriangleFilterF != null && TriangleFilterF(tj) == false)
+                        continue;
+                    mesh.GetTriVertices(tj, ref otri.V0, ref otri.V1, ref otri.V2);
+                    if (TransformF != null)
+                    {
+                        otri.V0 = TransformF(otri.V0);
+                        otri.V1 = TransformF(otri.V1);
+                        otri.V2 = TransformF(otri.V2);
+                    }
+                    intr.Triangle0 = otri;
+                    var vertices = mesh.GetTriangle(tj);
+
+                    var neighboringTriangles = new List<int>();
+                    mesh.GetVtxTriangles(vertices.a, neighboringTriangles, false);
+                    mesh.GetVtxTriangles(vertices.b, neighboringTriangles, false);
+                    mesh.GetVtxTriangles(vertices.c, neighboringTriangles, false);
+                    neighboringTriangles = neighboringTriangles.Distinct().ToList();
+
+                    // inner iteration over "our" triangles
+                    for (int i = 1; i <= num_tris; ++i)
+                    {
+                        int ti = index_list[idx + i];
+
+                        // Checks if it is the same triangle, or if they are neighbors
+                        //if (ti == tj || ti == neighbors.a || ti == neighbors.b || ti == neighbors.c)
+                        if (neighboringTriangles.Contains(ti))
+                            continue;
+
+                        if (TriangleFilterF != null && TriangleFilterF(ti) == false)
+                            continue;
+
+                        mesh.GetTriVertices(ti, ref tri.V0, ref tri.V1, ref tri.V2);
+                        intr.Triangle1 = tri;
+
+                        // [RMS] Test() is much faster than Find() so it makes sense to call it first, as most
+                        // triangles will not intersect (right?)
+                        if (intr.Test())
+                        {
+                            result.TrianglePairs.Add((ti, tj));
+                        }
+                    }
+                }
+
+                // done these nodes
+                return;
+            }
+
+            // we either descend "our" tree or the other tree
+            //   - if we have hit triangles on "our" tree, we have to descend other
+            //   - if we hit triangles on "other", we have to descend ours
+            //   - otherwise, we alternate at each depth. This produces wider
+            //     branching but is significantly faster (~10x) for both hits and misses
+            bool bDescendOther = (idx < triangles_end || depth % 2 == 0);
+            if (bDescendOther && odx < triangles_end)
+                bDescendOther = false;      // can't
+
+            if (bDescendOther)
+            {
+                // ok we hit triangles on our side but we need to still reach triangles on
+                // the other side, so we descend "their" children
+
+                // [TODO] could we do efficient box.intersects(transform(box)) test?
+                //   ( Contains() on each xformed point? )
+                AxisAlignedBox3d bounds = get_boxd(iBox);
+
+                int oChild1 = index_list[odx];
+                if (oChild1 < 0)
+                {                 // 1 child, descend if nearer than cur min-dist
+                    oChild1 = (-oChild1) - 1;
+                    AxisAlignedBox3d oChild1Box = get_boxd(oChild1, TransformF);
+                    if (oChild1Box.Intersects(bounds))
+                        find_self_intersection_triangles(iBox, TransformF, oChild1, depth + 1, intr, result);
+
+                }
+                else
+                {                            // 2 children
+                    oChild1 = oChild1 - 1;
+
+                    AxisAlignedBox3d oChild1Box = get_boxd(oChild1, TransformF);
+                    if (oChild1Box.Intersects(bounds))
+                        find_self_intersection_triangles(iBox, TransformF, oChild1, depth + 1, intr, result);
+
+                    int oChild2 = index_list[odx + 1] - 1;
+                    AxisAlignedBox3d oChild2Box = get_boxd(oChild2, TransformF);
+                    if (oChild2Box.Intersects(bounds))
+                        find_self_intersection_triangles(iBox, TransformF, oChild2, depth + 1, intr, result);
+                }
+
+            }
+            else
+            {
+                // descend our tree nodes if they intersect w/ current bounds of other tree
+                AxisAlignedBox3d oBounds = get_boxd(oBox, TransformF);
+
+                int iChild1 = index_list[idx];
+                if (iChild1 < 0)
+                {                 // 1 child, descend if nearer than cur min-dist
+                    iChild1 = (-iChild1) - 1;
+                    if (box_box_intersect(iChild1, ref oBounds))
+                        find_self_intersection_triangles(iChild1, TransformF, oBox, depth + 1, intr, result);
+
+                }
+                else
+                {                            // 2 children
+                    iChild1 = iChild1 - 1;
+                    if (box_box_intersect(iChild1, ref oBounds))
+                        find_self_intersection_triangles(iChild1, TransformF, oBox, depth + 1, intr, result);
+
+                    int iChild2 = index_list[idx + 1] - 1;
+                    if (box_box_intersect(iChild2, ref oBounds))
+                        find_self_intersection_triangles(iChild2, TransformF, oBox, depth + 1, intr, result);
+                }
+
+            }
+        }
+
 
         protected void find_intersections(int iBox, DMeshAABBTree3 otherTree, Func<Vector3d, Vector3d> TransformF,
                                           int oBox, int depth,

--- a/spatial/DMeshAABBTree.cs
+++ b/spatial/DMeshAABBTree.cs
@@ -1103,12 +1103,12 @@ namespace g4
                         otri.V2 = TransformF(otri.V2);
                     }
                     intr.Triangle0 = otri;
-                    var vertices = mesh.GetTriangle(tj);
+                    var edges = mesh.GetTriEdges(tj);
+                    var trisA = mesh.GetEdgeT(edges.a);
+                    var trisB = mesh.GetEdgeT(edges.b);
+                    var trisC = mesh.GetEdgeT(edges.c);
 
-                    var neighboringTriangles = new List<int>();
-                    mesh.GetVtxTriangles(vertices.a, neighboringTriangles, false);
-                    mesh.GetVtxTriangles(vertices.b, neighboringTriangles, false);
-                    mesh.GetVtxTriangles(vertices.c, neighboringTriangles, false);
+                    var neighboringTriangles = new List<int> { trisA.a, trisA.b, trisB.a, trisB.b, trisC.a, trisC.b };
                     neighboringTriangles = neighboringTriangles.Distinct().ToList();
 
                     // inner iteration over "our" triangles
@@ -1117,7 +1117,6 @@ namespace g4
                         int ti = index_list[idx + i];
 
                         // Checks if it is the same triangle, or if they are neighbors
-                        //if (ti == tj || ti == neighbors.a || ti == neighbors.b || ti == neighbors.c)
                         if (neighboringTriangles.Contains(ti))
                             continue;
 
@@ -1129,7 +1128,7 @@ namespace g4
 
                         // [RMS] Test() is much faster than Find() so it makes sense to call it first, as most
                         // triangles will not intersect (right?)
-                        if (intr.Test())
+                        if (intr.Find() && intr.Type != IntersectionType.Point)
                         {
                             result.TrianglePairs.Add((ti, tj));
                         }

--- a/spatial/NTMeshAABBTree.cs
+++ b/spatial/NTMeshAABBTree.cs
@@ -1199,13 +1199,9 @@ namespace g4
                         otri.V2 = TransformF(otri.V2);
                     }
                     intr.Triangle0 = otri;
-                    var vertices = mesh.GetTriangle(tj);
                     var edges = mesh.GetTriEdges(tj);
 
                     var neighboringTriangles = new List<int>();
-                    //mesh.GetVtxTriangles(vertices.a, neighboringTriangles);
-                    //mesh.GetVtxTriangles(vertices.b, neighboringTriangles);
-                    //mesh.GetVtxTriangles(vertices.c, neighboringTriangles);
                     neighboringTriangles.AddRange(mesh.EdgeTrianglesItr(edges.a));
                     neighboringTriangles.AddRange(mesh.EdgeTrianglesItr(edges.b));
                     neighboringTriangles.AddRange(mesh.EdgeTrianglesItr(edges.c));
@@ -1217,7 +1213,6 @@ namespace g4
                         int ti = index_list[idx + i];
 
                         // Checks if it is the same triangle, or if they are neighbors
-                        //if (ti == tj || ti == neighbors.a || ti == neighbors.b || ti == neighbors.c)
                         if (neighboringTriangles.Contains(ti))
                             continue;
 

--- a/spatial/NTMeshAABBTree.cs
+++ b/spatial/NTMeshAABBTree.cs
@@ -1151,6 +1151,161 @@ namespace g4
             return result;
         }
 
+        /// <summary>
+        /// Compute all self-intersections of a mesh. 
+        /// TransformF argument transforms vertices of otherTree to our tree (can be null if in same coord space)
+        /// Returns pairs of intersecting triangles, which could intersect in either point or segment
+        /// </summary>
+        public virtual IntersectionsTrianglesQueryResult FindAllSelfIntersectionsTriangles(Func<Vector3d, Vector3d> TransformF = null)
+        {
+            if (mesh_timestamp != mesh.ShapeTimestamp)
+                throw new Exception("DMeshAABBTree3.FindIntersections: mesh has been modified since tree construction");
+
+            var result = new IntersectionsTrianglesQueryResult
+            {
+                TrianglePairs = new List<(int, int)>()
+            };
+
+            var intr = new IntrTriangle3Triangle3(new Triangle3d(), new Triangle3d());
+            find_self_intersection_triangles(root_index, TransformF, root_index, 0, intr, result);
+
+            return result;
+        }
+
+        protected void find_self_intersection_triangles(int iBox, Func<Vector3d, Vector3d> TransformF,
+                                  int oBox, int depth,
+                                  IntrTriangle3Triangle3 intr, IntersectionsTrianglesQueryResult result)
+        {
+            int idx = box_to_index[iBox];
+            int odx = box_to_index[oBox];
+
+            if (idx < triangles_end && odx < triangles_end)
+            {
+                // ok we are at triangles for both trees, do triangle-level testing
+                Triangle3d tri = new Triangle3d(), otri = new Triangle3d();
+                int num_tris = index_list[idx], onum_tris = index_list[odx];
+
+                // outer iteration is "other" tris that need to be transformed (more expensive)
+                for (int j = 1; j <= onum_tris; ++j)
+                {
+                    int tj = index_list[odx + j];
+                    if (TriangleFilterF != null && TriangleFilterF(tj) == false)
+                        continue;
+                    mesh.GetTriVertices(tj, ref otri.V0, ref otri.V1, ref otri.V2);
+                    if (TransformF != null)
+                    {
+                        otri.V0 = TransformF(otri.V0);
+                        otri.V1 = TransformF(otri.V1);
+                        otri.V2 = TransformF(otri.V2);
+                    }
+                    intr.Triangle0 = otri;
+                    var vertices = mesh.GetTriangle(tj);
+
+                    var neighboringTriangles = new List<int>();
+                    mesh.GetVtxTriangles(vertices.a, neighboringTriangles);
+                    mesh.GetVtxTriangles(vertices.b, neighboringTriangles);
+                    mesh.GetVtxTriangles(vertices.c, neighboringTriangles);
+                    neighboringTriangles = neighboringTriangles.Distinct().ToList();
+
+                    // inner iteration over "our" triangles
+                    for (int i = 1; i <= num_tris; ++i)
+                    {
+                        int ti = index_list[idx + i];
+
+                        // Checks if it is the same triangle, or if they are neighbors
+                        //if (ti == tj || ti == neighbors.a || ti == neighbors.b || ti == neighbors.c)
+                        if (neighboringTriangles.Contains(ti))
+                            continue;
+
+                        if (TriangleFilterF != null && TriangleFilterF(ti) == false)
+                            continue;
+
+                        mesh.GetTriVertices(ti, ref tri.V0, ref tri.V1, ref tri.V2);
+                        intr.Triangle1 = tri;
+
+                        // [RMS] Test() is much faster than Find() so it makes sense to call it first, as most
+                        // triangles will not intersect (right?)
+                        if (intr.Test())
+                        {
+                            result.TrianglePairs.Add((ti, tj));
+                        }
+                    }
+                }
+
+                // done these nodes
+                return;
+            }
+
+            // we either descend "our" tree or the other tree
+            //   - if we have hit triangles on "our" tree, we have to descend other
+            //   - if we hit triangles on "other", we have to descend ours
+            //   - otherwise, we alternate at each depth. This produces wider
+            //     branching but is significantly faster (~10x) for both hits and misses
+            bool bDescendOther = (idx < triangles_end || depth % 2 == 0);
+            if (bDescendOther && odx < triangles_end)
+                bDescendOther = false;      // can't
+
+            if (bDescendOther)
+            {
+                // ok we hit triangles on our side but we need to still reach triangles on
+                // the other side, so we descend "their" children
+
+                // [TODO] could we do efficient box.intersects(transform(box)) test?
+                //   ( Contains() on each xformed point? )
+                AxisAlignedBox3d bounds = get_boxd(iBox);
+
+                int oChild1 = index_list[odx];
+                if (oChild1 < 0)
+                {                 // 1 child, descend if nearer than cur min-dist
+                    oChild1 = (-oChild1) - 1;
+                    AxisAlignedBox3d oChild1Box = get_boxd(oChild1, TransformF);
+                    if (oChild1Box.Intersects(bounds))
+                        find_self_intersection_triangles(iBox, TransformF, oChild1, depth + 1, intr, result);
+
+                }
+                else
+                {                            // 2 children
+                    oChild1 = oChild1 - 1;
+
+                    AxisAlignedBox3d oChild1Box = get_boxd(oChild1, TransformF);
+                    if (oChild1Box.Intersects(bounds))
+                        find_self_intersection_triangles(iBox, TransformF, oChild1, depth + 1, intr, result);
+
+                    int oChild2 = index_list[odx + 1] - 1;
+                    AxisAlignedBox3d oChild2Box = get_boxd(oChild2, TransformF);
+                    if (oChild2Box.Intersects(bounds))
+                        find_self_intersection_triangles(iBox, TransformF, oChild2, depth + 1, intr, result);
+                }
+
+            }
+            else
+            {
+                // descend our tree nodes if they intersect w/ current bounds of other tree
+                AxisAlignedBox3d oBounds = get_boxd(oBox, TransformF);
+
+                int iChild1 = index_list[idx];
+                if (iChild1 < 0)
+                {                 // 1 child, descend if nearer than cur min-dist
+                    iChild1 = (-iChild1) - 1;
+                    if (box_box_intersect(iChild1, ref oBounds))
+                        find_self_intersection_triangles(iChild1, TransformF, oBox, depth + 1, intr, result);
+
+                }
+                else
+                {                            // 2 children
+                    iChild1 = iChild1 - 1;
+                    if (box_box_intersect(iChild1, ref oBounds))
+                        find_self_intersection_triangles(iChild1, TransformF, oBox, depth + 1, intr, result);
+
+                    int iChild2 = index_list[idx + 1] - 1;
+                    if (box_box_intersect(iChild2, ref oBounds))
+                        find_self_intersection_triangles(iChild2, TransformF, oBox, depth + 1, intr, result);
+                }
+
+            }
+        }
+
+
         protected void find_intersections(int iBox, NTMeshAABBTree3 otherTree, Func<Vector3d, Vector3d> TransformF,
                                           int oBox, int depth,
                                           IntrTriangle3Triangle3 intr, IntersectionsAndTrianglesQueryResult result)

--- a/spatial/NTMeshAABBTree.cs
+++ b/spatial/NTMeshAABBTree.cs
@@ -1763,6 +1763,29 @@ namespace g4
             return (nHits % 2) != 0;
         }
 
+        /// <summary>
+        /// Returns true if point p is inside this mesh.
+        /// </summary>
+        public virtual bool IsInside(Vector3d p, Vector3d n)
+        {
+            // This is a raycast crossing-count test, which is not ideal!
+            // Only works for closed meshes.
+
+            //AxisAlignedBox3f bounds = get_box(root_index);
+            //Vector3d outside = bounds.Center + 2 * bounds.Diagonal;
+
+            //Vector3d rayDir = Vector3d.AxisX;
+
+            Vector3d rayDir = n.Normalized;
+
+            //Vector3d rayOrigin = p - 2 * bounds.Width * rayDir;
+            Vector3d rayOrigin = p;
+
+            Ray3d ray = new Ray3d(rayOrigin, rayDir);
+            int nHits = FindAllHitTriangles(ray, null);
+
+            return (nHits % 2) != 0;
+        }
 
 
 

--- a/spatial/NTMeshAABBTree.cs
+++ b/spatial/NTMeshAABBTree.cs
@@ -1200,11 +1200,15 @@ namespace g4
                     }
                     intr.Triangle0 = otri;
                     var vertices = mesh.GetTriangle(tj);
+                    var edges = mesh.GetTriEdges(tj);
 
                     var neighboringTriangles = new List<int>();
-                    mesh.GetVtxTriangles(vertices.a, neighboringTriangles);
-                    mesh.GetVtxTriangles(vertices.b, neighboringTriangles);
-                    mesh.GetVtxTriangles(vertices.c, neighboringTriangles);
+                    //mesh.GetVtxTriangles(vertices.a, neighboringTriangles);
+                    //mesh.GetVtxTriangles(vertices.b, neighboringTriangles);
+                    //mesh.GetVtxTriangles(vertices.c, neighboringTriangles);
+                    neighboringTriangles.AddRange(mesh.EdgeTrianglesItr(edges.a));
+                    neighboringTriangles.AddRange(mesh.EdgeTrianglesItr(edges.b));
+                    neighboringTriangles.AddRange(mesh.EdgeTrianglesItr(edges.c));
                     neighboringTriangles = neighboringTriangles.Distinct().ToList();
 
                     // inner iteration over "our" triangles
@@ -1225,7 +1229,7 @@ namespace g4
 
                         // [RMS] Test() is much faster than Find() so it makes sense to call it first, as most
                         // triangles will not intersect (right?)
-                        if (intr.Test())
+                        if (intr.Find() && intr.Type != IntersectionType.Point)
                         {
                             result.TrianglePairs.Add((ti, tj));
                         }

--- a/spatial/NTMeshAABBTree.cs
+++ b/spatial/NTMeshAABBTree.cs
@@ -1159,7 +1159,7 @@ namespace g4
         public virtual IntersectionsTrianglesQueryResult FindAllSelfIntersectionsTriangles(Func<Vector3d, Vector3d> TransformF = null)
         {
             if (mesh_timestamp != mesh.ShapeTimestamp)
-                throw new Exception("DMeshAABBTree3.FindIntersections: mesh has been modified since tree construction");
+                throw new Exception("NTMeshAABBTree3.FindIntersections: mesh has been modified since tree construction");
 
             var result = new IntersectionsTrianglesQueryResult
             {


### PR DESCRIPTION
New classes adapted from `DMesh3` to support non-manifold `NTMesh3`:
- **NTMergeCoincidentEdges**: Like the `DMesh3` version, currently merges only boundary edges. An option could be added to merge non-boundary edges, as we are now working with non-manifold meshes.
- **NTMeshRepairOrientation**: Slightly different from the `DMesh3` version; skips non-manifold edges of triangles when traversing through its neighbours.
- **NTRemoveOccludedTrianlges**: Includes minor improvements over the `DMesh3` version.
- **NTMeshConnectedComponents**: Direct adaptation from the `DMesh3` version.
- **NTSimpleHoleFiller**: Direct adaptation from the `DMesh3` version.

Additional changes:
- Implemented several helper classes/methods for `NTMesh3`, including mesh editing operations (e.g., `NTMesh3.FlipEdges()`, `NTMesh3.MergeEdges()`).
- Added **FindAllSelfIntersectionsTriangles**, for both `DMeshAABBTree` and `NTMeshAABBTree`.
