### PR TITLE
Adding adjacency filter function to NTMeshConnectedComponents

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("1.1.1.0")]
-[assembly: AssemblyFileVersion("1.1.1.0")]
+[assembly: AssemblyVersion("1.1.2.0")]
+[assembly: AssemblyFileVersion("1.1.2.0")]
 
 #endif

--- a/geometry4SharpTests/distance/DistTriangle3Triangle3Tests.cs
+++ b/geometry4SharpTests/distance/DistTriangle3Triangle3Tests.cs
@@ -1,7 +1,6 @@
-using FluentAssertions;
+using Shouldly;
 
 using g4;
-using Xunit;
 
 namespace geometry4SharpTests.distance
 {
@@ -22,8 +21,8 @@ namespace geometry4SharpTests.distance
 
             var triangleDistance = new DistTriangle3Triangle3(triangleA, triangleB).Compute();
 
-            triangleDistance.Triangle0Closest.y.Should().BeApproximately(3.80, 0.1);
-            triangleDistance.Triangle1Closest.y.Should().BeApproximately(5.92, 0.1);
+            triangleDistance.Triangle0Closest.y.ShouldBe(3.80, 0.1);
+            triangleDistance.Triangle1Closest.y.ShouldBe(5.92, 0.1);
         }
 
         [Fact]
@@ -41,8 +40,8 @@ namespace geometry4SharpTests.distance
 
             var triangleDistance = new DistTriangle3Triangle3(triangleA, triangleB).Compute();
 
-            triangleDistance.Triangle0Closest.y.Should().BeApproximately(3.80, 0.1);
-            triangleDistance.Triangle1Closest.y.Should().BeApproximately(5.95, 0.1);
+            triangleDistance.Triangle0Closest.y.ShouldBe(3.80, 0.1);
+            triangleDistance.Triangle1Closest.y.ShouldBe(5.95, 0.1);
         }
 
         [Fact]
@@ -60,8 +59,8 @@ namespace geometry4SharpTests.distance
 
             var triangleDistance = new DistTriangle3Triangle3(triangleA, triangleB).Compute();
 
-            triangleDistance.Triangle0Closest.y.Should().BeApproximately(3.80, 0.1);
-            triangleDistance.Triangle1Closest.y.Should().BeApproximately(5.92, 0.1);
+            triangleDistance.Triangle0Closest.y.ShouldBe(3.80, 0.1);
+            triangleDistance.Triangle1Closest.y.ShouldBe(5.92, 0.1);
         }
 
         [Fact]
@@ -79,7 +78,7 @@ namespace geometry4SharpTests.distance
 
             var triangleDistance = new DistTriangle3Triangle3(triangleA, triangleB).Compute();
 
-            triangleDistance.DistanceSquared.Should().BeApproximately(0, 0.01);
+            triangleDistance.DistanceSquared.ShouldBe(0, 0.01);
         }
     }
 }

--- a/geometry4SharpTests/geometry4SharpTests.csproj
+++ b/geometry4SharpTests/geometry4SharpTests.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.9.3" />
   </ItemGroup>

--- a/geometry4SharpTests/math/Triangle3Tests.cs
+++ b/geometry4SharpTests/math/Triangle3Tests.cs
@@ -1,7 +1,6 @@
-using FluentAssertions;
+using Shouldly;
 
 using g4;
-using Xunit;
 
 namespace geometry4SharpTests
 {
@@ -19,12 +18,12 @@ namespace geometry4SharpTests
 
             var isPointOnTri = triangleA.IsPointInTriangle(pointA);
 
-            isPointOnTri.Should().BeFalse();
+            isPointOnTri.ShouldBeFalse();
 
 
             var pointB = new Vector3d(-21.01844597, 3.80000305, -5.53531647);
 
-            triangleA.IsPointInTriangle(pointB).Should().BeTrue();
+            triangleA.IsPointInTriangle(pointB).ShouldBeTrue();
         }
 
         [Fact]
@@ -37,7 +36,7 @@ namespace geometry4SharpTests
 
             var pointB = new Vector3d(-21.01844597, 3.80000305, -5.53531647);
 
-            triangleA.IsPointInTriangle(pointB).Should().BeTrue();
+            triangleA.IsPointInTriangle(pointB).ShouldBeTrue();
         }
     }
 }

--- a/geometry4SharpTests/mesh_ops/NTMeshRepairOrientationTests.cs
+++ b/geometry4SharpTests/mesh_ops/NTMeshRepairOrientationTests.cs
@@ -1,0 +1,179 @@
+using Shouldly;
+
+using g4;
+using gs;
+
+namespace geometry4SharpTests.mesh_ops
+{
+    public class NTMeshRepairOrientationTests
+    {
+        #region Test Data
+        private static NTMesh3 CreateCube()
+        {
+            var mesh = new NTMesh3();
+
+            var v0 = mesh.AppendVertex(new Vector3d(-1.0, 1.0, -1.0));
+            var v1 = mesh.AppendVertex(new Vector3d(-1.0, 1.0, 1.0));
+            var v2 = mesh.AppendVertex(new Vector3d(1.0, 1.0, -1.0));
+            var v3 = mesh.AppendVertex(new Vector3d(1.0, 1.0, 1.0));
+
+            var v4 = mesh.AppendVertex(new Vector3d(-1.0, -1.0, -1.0));
+            var v5 = mesh.AppendVertex(new Vector3d(-1.0, -1.0, 1.0));
+            var v6 = mesh.AppendVertex(new Vector3d(1.0, -1.0, -1.0));
+            var v7 = mesh.AppendVertex(new Vector3d(1.0, -1.0, 1.0));
+
+            mesh.AppendTriangle(v3, v2, v0);
+            mesh.AppendTriangle(v0, v1, v3);
+            mesh.AppendTriangle(v4, v6, v7);
+            mesh.AppendTriangle(v7, v5, v4);
+
+            mesh.AppendTriangle(v6, v2, v3);
+            mesh.AppendTriangle(v3, v7, v6);
+            mesh.AppendTriangle(v1, v0, v4);
+            mesh.AppendTriangle(v4, v5, v1);
+
+            mesh.AppendTriangle(v5, v7, v3);
+            mesh.AppendTriangle(v3, v1, v5);
+            mesh.AppendTriangle(v2, v6, v4);
+            mesh.AppendTriangle(v4, v0, v2);
+
+            return mesh;
+        }
+
+        private static NTMesh3 CreateCubeSingleInvertedTriangle()
+        {
+            var mesh = new NTMesh3();
+
+            var v0 = mesh.AppendVertex(new Vector3d(-1.0, 1.0, -1.0));
+            var v1 = mesh.AppendVertex(new Vector3d(-1.0, 1.0, 1.0));
+            var v2 = mesh.AppendVertex(new Vector3d(1.0, 1.0, -1.0));
+            var v3 = mesh.AppendVertex(new Vector3d(1.0, 1.0, 1.0));
+
+            var v4 = mesh.AppendVertex(new Vector3d(-1.0, -1.0, -1.0));
+            var v5 = mesh.AppendVertex(new Vector3d(-1.0, -1.0, 1.0));
+            var v6 = mesh.AppendVertex(new Vector3d(1.0, -1.0, -1.0));
+            var v7 = mesh.AppendVertex(new Vector3d(1.0, -1.0, 1.0));
+
+            mesh.AppendTriangle(v3, v2, v0); 
+            mesh.AppendTriangle(v3, v1, v0); // Inverted triangle
+            mesh.AppendTriangle(v4, v6, v7);
+            mesh.AppendTriangle(v7, v5, v4);
+
+            mesh.AppendTriangle(v6, v2, v3);
+            mesh.AppendTriangle(v3, v7, v6);
+            mesh.AppendTriangle(v1, v0, v4);
+            mesh.AppendTriangle(v4, v5, v1);
+
+            mesh.AppendTriangle(v5, v7, v3);
+            mesh.AppendTriangle(v3, v1, v5);
+            mesh.AppendTriangle(v2, v6, v4);
+            mesh.AppendTriangle(v4, v0, v2);
+
+            return mesh;
+        }
+
+        private static NTMesh3 CreateInvertedCube()
+        {
+            var mesh = new NTMesh3();
+
+            var v0 = mesh.AppendVertex(new Vector3d(-1.0, 1.0, -1.0));
+            var v1 = mesh.AppendVertex(new Vector3d(-1.0, 1.0, 1.0));
+            var v2 = mesh.AppendVertex(new Vector3d(1.0, 1.0, -1.0));
+            var v3 = mesh.AppendVertex(new Vector3d(1.0, 1.0, 1.0));
+
+            var v4 = mesh.AppendVertex(new Vector3d(-1.0, -1.0, -1.0));
+            var v5 = mesh.AppendVertex(new Vector3d(-1.0, -1.0, 1.0));
+            var v6 = mesh.AppendVertex(new Vector3d(1.0, -1.0, -1.0));
+            var v7 = mesh.AppendVertex(new Vector3d(1.0, -1.0, 1.0));
+
+            mesh.AppendTriangle(v0, v2, v3);
+            mesh.AppendTriangle(v3, v1, v0);
+            mesh.AppendTriangle(v7, v6, v4);
+            mesh.AppendTriangle(v4, v5, v7);
+
+            mesh.AppendTriangle(v3, v2, v6);
+            mesh.AppendTriangle(v6, v7, v3);
+            mesh.AppendTriangle(v4, v0, v1);
+            mesh.AppendTriangle(v1, v5, v4);
+
+            mesh.AppendTriangle(v3, v7, v5);
+            mesh.AppendTriangle(v5, v1, v3);
+            mesh.AppendTriangle(v4, v6, v2);
+            mesh.AppendTriangle(v2, v0, v4);
+
+            return mesh;
+        }
+        #endregion
+
+        [Fact]
+        public void NTMeshRepairOrientation_OrientComponents_Cube()
+        {
+            var mesh = CreateCube();
+            var timestamp = mesh.Timestamp;
+
+            var repair = new NTMeshRepairOrientation(mesh);
+            repair.OrientComponents();
+
+            // Mesh should still be the same as the original
+            mesh.Timestamp.ShouldBe(timestamp);
+        }
+
+        [Fact]
+        public void NTMeshRepairOrientation_OrientComponents_CubeSingleInvertedTriangle()
+        {
+            var mesh = CreateCubeSingleInvertedTriangle();
+            var timestamp = mesh.Timestamp;
+
+            var repair = new NTMeshRepairOrientation(mesh);
+            repair.OrientComponents();
+
+            // A single triangle must be inverted (the second one)
+            mesh.Timestamp.ShouldBe(timestamp + 1);
+        }
+
+        [Fact]
+        public void NTMeshRepairOrientation_OrientComponents_InvertedCube()
+        {
+            var mesh = CreateInvertedCube();
+            var timestamp = mesh.Timestamp;
+
+            var repair = new NTMeshRepairOrientation(mesh);
+            repair.OrientComponents();
+
+            // Mesh should still be the same as the original
+            mesh.Timestamp.ShouldBe(timestamp);
+        }
+
+        [Fact]
+        public void NTMeshRepairOrientation_SolveGlobalOrientation_Cube()
+        {
+            var mesh = CreateCube();
+            var timestamp = mesh.Timestamp;
+
+            var repair = new NTMeshRepairOrientation(mesh);
+            repair.OrientComponents();
+            repair.SolveGlobalOrientation();
+
+            // All triangles face outwards, so the mesh should still be the same as the original
+            mesh.Timestamp.ShouldBe(timestamp);
+        }
+
+        [Fact]
+        public void NTMeshRepairOrientation_SolveGlobalOrientation_InvertedCube()
+        {
+            var mesh = CreateInvertedCube();
+            var timestamp = mesh.Timestamp;
+
+            var repair = new NTMeshRepairOrientation(mesh);
+            repair.OrientComponents();
+            mesh.Timestamp.ShouldBe(timestamp);
+
+            repair.SolveGlobalOrientation();
+
+            // All triangles face inwards, all 12 triangles of the cube are inverted.
+            // Besides, we also invert the normal of all 8 vertices, although we do
+            // not use them.
+            mesh.Timestamp.ShouldBe(timestamp + 20);
+        }
+    }
+}

--- a/geometry4SharpTests/mesh_ops/NTRemoveOccludedTrianglesTests.cs
+++ b/geometry4SharpTests/mesh_ops/NTRemoveOccludedTrianglesTests.cs
@@ -1,0 +1,112 @@
+using Shouldly;
+
+using g4;
+using gs;
+
+namespace geometry4SharpTests.mesh_ops
+{
+    public class NTRemoveOccludedTrianglesTests
+    {
+        #region Test Data
+        private static NTMesh3 CreateCube()
+        {
+            var mesh = new NTMesh3();
+
+            var v0 = mesh.AppendVertex(new Vector3d(-1.0, 1.0, -1.0));
+            var v1 = mesh.AppendVertex(new Vector3d(-1.0, 1.0, 1.0));
+            var v2 = mesh.AppendVertex(new Vector3d(1.0, 1.0, -1.0));
+            var v3 = mesh.AppendVertex(new Vector3d(1.0, 1.0, 1.0));
+
+            var v4 = mesh.AppendVertex(new Vector3d(-1.0, -1.0, -1.0));
+            var v5 = mesh.AppendVertex(new Vector3d(-1.0, -1.0, 1.0));
+            var v6 = mesh.AppendVertex(new Vector3d(1.0, -1.0, -1.0));
+            var v7 = mesh.AppendVertex(new Vector3d(1.0, -1.0, 1.0));
+
+            mesh.AppendTriangle(v3, v2, v0);
+            mesh.AppendTriangle(v0, v1, v3);
+            mesh.AppendTriangle(v4, v6, v7);
+            mesh.AppendTriangle(v7, v5, v4);
+
+            mesh.AppendTriangle(v6, v2, v3);
+            mesh.AppendTriangle(v3, v7, v6);
+            mesh.AppendTriangle(v1, v0, v4);
+            mesh.AppendTriangle(v4, v5, v1);
+
+            mesh.AppendTriangle(v5, v7, v3);
+            mesh.AppendTriangle(v3, v1, v5);
+            mesh.AppendTriangle(v2, v6, v4);
+            mesh.AppendTriangle(v4, v0, v2);
+
+            return mesh;
+        }
+
+        private static NTMesh3 CreateCubeWithTriangleInside()
+        {
+            var mesh = new NTMesh3();
+
+            var v0 = mesh.AppendVertex(new Vector3d(-1.0, 1.0, -1.0));
+            var v1 = mesh.AppendVertex(new Vector3d(-1.0, 1.0, 1.0));
+            var v2 = mesh.AppendVertex(new Vector3d(1.0, 1.0, -1.0));
+            var v3 = mesh.AppendVertex(new Vector3d(1.0, 1.0, 1.0));
+
+            var v4 = mesh.AppendVertex(new Vector3d(-1.0, -1.0, -1.0));
+            var v5 = mesh.AppendVertex(new Vector3d(-1.0, -1.0, 1.0));
+            var v6 = mesh.AppendVertex(new Vector3d(1.0, -1.0, -1.0));
+            var v7 = mesh.AppendVertex(new Vector3d(1.0, -1.0, 1.0));
+
+            var v8 = mesh.AppendVertex(new Vector3d(0.0, 0.0, 0.0));
+            var v9 = mesh.AppendVertex(new Vector3d(0.5, 0.0, 0.0));
+            var v10 = mesh.AppendVertex(new Vector3d(0.0, 0.0, 0.5));
+
+            mesh.AppendTriangle(v3, v2, v0);
+            mesh.AppendTriangle(v0, v1, v3);
+            mesh.AppendTriangle(v4, v6, v7);
+            mesh.AppendTriangle(v7, v5, v4);
+
+            mesh.AppendTriangle(v6, v2, v3);
+            mesh.AppendTriangle(v3, v7, v6);
+            mesh.AppendTriangle(v1, v0, v4);
+            mesh.AppendTriangle(v4, v5, v1);
+
+            mesh.AppendTriangle(v5, v7, v3);
+            mesh.AppendTriangle(v3, v1, v5);
+            mesh.AppendTriangle(v2, v6, v4);
+            mesh.AppendTriangle(v4, v0, v2);
+
+            mesh.AppendTriangle(v8, v9, v10);
+
+            return mesh;
+        }
+        #endregion
+
+        [Fact]
+        public void NTRemoveOccludedTriangles_Cube()
+        {
+            var mesh = CreateCube();
+            var timestamp = mesh.Timestamp;
+            var numTriangles = mesh.TriangleCount;
+
+            var repair = new NTRemoveOccludedTriangles(mesh);
+            repair.Apply();
+
+            // Mesh should still be the same as the original
+            mesh.Timestamp.ShouldBe(timestamp);
+            mesh.TriangleCount.ShouldBe(numTriangles);
+        }
+
+        [Fact]
+        public void NTRemoveOccludedTriangles_CubeWithTriangleInside()
+        {
+            var mesh = CreateCubeWithTriangleInside();
+            var timestamp = mesh.Timestamp;
+            var numTriangles = mesh.TriangleCount;
+
+            var repair = new NTRemoveOccludedTriangles(mesh);
+            repair.Apply();
+
+            // One triangle from the mesh should be removed
+            mesh.Timestamp.ShouldBe(timestamp + 1);
+            mesh.TriangleCount.ShouldBe(numTriangles - 1);
+        }
+    }
+}

--- a/geometry4SharpTests/mesh_ops/NTSimpleHoleFillerTests.cs
+++ b/geometry4SharpTests/mesh_ops/NTSimpleHoleFillerTests.cs
@@ -1,0 +1,153 @@
+using Shouldly;
+
+using g4;
+using gs;
+
+namespace geometry4SharpTests.mesh_ops
+{
+    public class NTSimpleHoleFillerTests
+    {
+        #region Test Data
+        private static NTMesh3 CreateCube()
+        {
+            var mesh = new NTMesh3();
+
+            var v0 = mesh.AppendVertex(new Vector3d(-1.0, 1.0, -1.0));
+            var v1 = mesh.AppendVertex(new Vector3d(-1.0, 1.0, 1.0));
+            var v2 = mesh.AppendVertex(new Vector3d(1.0, 1.0, -1.0));
+            var v3 = mesh.AppendVertex(new Vector3d(1.0, 1.0, 1.0));
+
+            var v4 = mesh.AppendVertex(new Vector3d(-1.0, -1.0, -1.0));
+            var v5 = mesh.AppendVertex(new Vector3d(-1.0, -1.0, 1.0));
+            var v6 = mesh.AppendVertex(new Vector3d(1.0, -1.0, -1.0));
+            var v7 = mesh.AppendVertex(new Vector3d(1.0, -1.0, 1.0));
+
+            mesh.AppendTriangle(v3, v2, v0);
+            mesh.AppendTriangle(v0, v1, v3);
+            mesh.AppendTriangle(v4, v6, v7);
+            mesh.AppendTriangle(v7, v5, v4);
+
+            mesh.AppendTriangle(v6, v2, v3);
+            mesh.AppendTriangle(v3, v7, v6);
+            mesh.AppendTriangle(v1, v0, v4);
+            mesh.AppendTriangle(v4, v5, v1);
+
+            mesh.AppendTriangle(v5, v7, v3);
+            mesh.AppendTriangle(v3, v1, v5);
+            mesh.AppendTriangle(v2, v6, v4);
+            mesh.AppendTriangle(v4, v0, v2);
+
+            return mesh;
+        }
+
+        private static NTMesh3 CreateCubeWithOneMissingTriangle()
+        {
+            var mesh = new NTMesh3();
+
+            var v0 = mesh.AppendVertex(new Vector3d(-1.0, 1.0, -1.0));
+            var v1 = mesh.AppendVertex(new Vector3d(-1.0, 1.0, 1.0));
+            var v2 = mesh.AppendVertex(new Vector3d(1.0, 1.0, -1.0));
+            var v3 = mesh.AppendVertex(new Vector3d(1.0, 1.0, 1.0));
+
+            var v4 = mesh.AppendVertex(new Vector3d(-1.0, -1.0, -1.0));
+            var v5 = mesh.AppendVertex(new Vector3d(-1.0, -1.0, 1.0));
+            var v6 = mesh.AppendVertex(new Vector3d(1.0, -1.0, -1.0));
+            var v7 = mesh.AppendVertex(new Vector3d(1.0, -1.0, 1.0));
+
+            mesh.AppendTriangle(v0, v1, v3);
+            mesh.AppendTriangle(v4, v6, v7);
+            mesh.AppendTriangle(v7, v5, v4);
+
+            mesh.AppendTriangle(v6, v2, v3);
+            mesh.AppendTriangle(v3, v7, v6);
+            mesh.AppendTriangle(v1, v0, v4);
+            mesh.AppendTriangle(v4, v5, v1);
+
+            mesh.AppendTriangle(v5, v7, v3);
+            mesh.AppendTriangle(v3, v1, v5);
+            mesh.AppendTriangle(v2, v6, v4);
+            mesh.AppendTriangle(v4, v0, v2);
+
+            return mesh;
+        }
+
+        private static NTMesh3 CreateCubeWithTwoMissingTriangles()
+        {
+            var mesh = new NTMesh3();
+
+            var v0 = mesh.AppendVertex(new Vector3d(-1.0, 1.0, -1.0));
+            var v1 = mesh.AppendVertex(new Vector3d(-1.0, 1.0, 1.0));
+            var v2 = mesh.AppendVertex(new Vector3d(1.0, 1.0, -1.0));
+            var v3 = mesh.AppendVertex(new Vector3d(1.0, 1.0, 1.0));
+
+            var v4 = mesh.AppendVertex(new Vector3d(-1.0, -1.0, -1.0));
+            var v5 = mesh.AppendVertex(new Vector3d(-1.0, -1.0, 1.0));
+            var v6 = mesh.AppendVertex(new Vector3d(1.0, -1.0, -1.0));
+            var v7 = mesh.AppendVertex(new Vector3d(1.0, -1.0, 1.0));
+
+            mesh.AppendTriangle(v4, v6, v7);
+            mesh.AppendTriangle(v7, v5, v4);
+
+            mesh.AppendTriangle(v6, v2, v3);
+            mesh.AppendTriangle(v3, v7, v6);
+            mesh.AppendTriangle(v1, v0, v4);
+            mesh.AppendTriangle(v4, v5, v1);
+
+            mesh.AppendTriangle(v5, v7, v3);
+            mesh.AppendTriangle(v3, v1, v5);
+            mesh.AppendTriangle(v2, v6, v4);
+            mesh.AppendTriangle(v4, v0, v2);
+
+            return mesh;
+        }
+        #endregion
+
+        [Fact]
+        public void NTSimpleHoleFiller_FillHoles_Cube()
+        {
+            var mesh = CreateCube();
+            var timestamp = mesh.Timestamp;
+            var numTriangles = mesh.TriangleCount;
+
+            NTSimpleHoleFiller.FillHoles(mesh);
+
+            // Mesh should still be the same as the original
+            mesh.Timestamp.ShouldBe(timestamp);
+            mesh.TriangleCount.ShouldBe(numTriangles);
+            mesh.IsClosed().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void NTSimpleHoleFiller_FillHoles_CubeWithOneMissingTriangle()
+        {
+            var mesh = CreateCubeWithOneMissingTriangle();
+            var timestamp = mesh.Timestamp;
+            var numTriangles = mesh.TriangleCount;
+
+            NTSimpleHoleFiller.FillHoles(mesh);
+
+            // A single triangle was missing, 
+            mesh.Timestamp.ShouldBe(timestamp + 1);
+            mesh.TriangleCount.ShouldBe(numTriangles + 1);
+            mesh.IsClosed().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void NTSimpleHoleFiller_FillHoles_CubeWithTwoMissingTriangles()
+        {
+            var mesh = CreateCubeWithTwoMissingTriangles();
+            var timestamp = mesh.Timestamp;
+            var numTriangles = mesh.TriangleCount;
+
+            NTSimpleHoleFiller.FillHoles(mesh);
+
+            // Both triangles of the top face were missing, resulting in a 4 vertices loop.
+            // The algorithm fills the hole by adding a new vertex at its cetroid, and
+            // generating a triangle fan with the loop vertices, resulting in 4 new
+            // triangles.
+            mesh.Timestamp.ShouldBe(timestamp + 5);         // 4 new triangles and 1 new vertex
+            mesh.TriangleCount.ShouldBe(numTriangles + 4);  // 4 new triangles (triangle fan)
+            mesh.IsClosed().ShouldBeTrue();
+        }
+    }
+}

--- a/geometry4SharpTests/mesh_selection/NTMeshConnectedComponents.cs
+++ b/geometry4SharpTests/mesh_selection/NTMeshConnectedComponents.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+
+using g4;
+
+namespace geometry4SharpTests.mesh_selection
+{
+    public class NTMeshConnectedComponentsTest
+    {
+        private static NTMesh3 CreateCube()
+        {
+            var mesh = new NTMesh3();
+
+            var v0 = mesh.AppendVertex(new Vector3d(-1.0, 1.0, -1.0));
+            var v1 = mesh.AppendVertex(new Vector3d(-1.0, 1.0, 1.0));
+            var v2 = mesh.AppendVertex(new Vector3d(1.0, 1.0, -1.0));
+            var v3 = mesh.AppendVertex(new Vector3d(1.0, 1.0, 1.0));
+
+            var v4 = mesh.AppendVertex(new Vector3d(-1.0, -1.0, -1.0));
+            var v5 = mesh.AppendVertex(new Vector3d(-1.0, -1.0, 1.0));
+            var v6 = mesh.AppendVertex(new Vector3d(1.0, -1.0, -1.0));
+            var v7 = mesh.AppendVertex(new Vector3d(1.0, -1.0, 1.0));
+
+            mesh.AppendTriangle(v3, v2, v0);
+            mesh.AppendTriangle(v0, v1, v3);
+            mesh.AppendTriangle(v4, v6, v7);
+            mesh.AppendTriangle(v7, v5, v4);
+
+            mesh.AppendTriangle(v6, v2, v3);
+            mesh.AppendTriangle(v3, v7, v6);
+            mesh.AppendTriangle(v1, v0, v4);
+            mesh.AppendTriangle(v4, v5, v1);
+
+            mesh.AppendTriangle(v5, v7, v3);
+            mesh.AppendTriangle(v3, v1, v5);
+            mesh.AppendTriangle(v2, v6, v4);
+            mesh.AppendTriangle(v4, v0, v2);
+
+            return mesh;
+        }
+
+        [Fact]
+        public void NTMeshConnectedComponents_Separate_Cube()
+        {
+            var mesh = CreateCube();
+            var components = NTMeshConnectedComponents.Separate(mesh);
+            components.Length.Should().Be(1);
+        }
+
+        [Fact]
+        public void NTMeshConnectedComponents_Separate_CubeByCoplanarTriangles()
+        {
+            bool AdjacencyFilterFunction(Triangle3d t0, Triangle3d t1)
+            {
+                return t0.Normal.Dot(t1.Normal) >= 0.9999;
+            }
+
+            var mesh = CreateCube();
+            var components = NTMeshConnectedComponents.Separate(mesh, AdjacencyFilterFunction);
+            components.Length.Should().Be(6);
+        }
+    }
+}

--- a/geometry4SharpTests/mesh_selection/NTMeshConnectedComponents.cs
+++ b/geometry4SharpTests/mesh_selection/NTMeshConnectedComponents.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using Shouldly;
 
 using g4;
 
@@ -43,7 +43,7 @@ namespace geometry4SharpTests.mesh_selection
         {
             var mesh = CreateCube();
             var components = NTMeshConnectedComponents.Separate(mesh);
-            components.Length.Should().Be(1);
+            components.Length.ShouldBe(1);
         }
 
         [Fact]
@@ -56,7 +56,7 @@ namespace geometry4SharpTests.mesh_selection
 
             var mesh = CreateCube();
             var components = NTMeshConnectedComponents.Separate(mesh, AdjacencyFilterFunction);
-            components.Length.Should().Be(6);
+            components.Length.ShouldBe(6);
         }
     }
 }

--- a/geometry4SharpTests/mesh_selection/NTMeshConnectedComponentsTests.cs
+++ b/geometry4SharpTests/mesh_selection/NTMeshConnectedComponentsTests.cs
@@ -4,8 +4,9 @@ using g4;
 
 namespace geometry4SharpTests.mesh_selection
 {
-    public class NTMeshConnectedComponentsTest
+    public class NTMeshConnectedComponentsTests
     {
+        #region Test Data
         private static NTMesh3 CreateCube()
         {
             var mesh = new NTMesh3();
@@ -37,6 +38,7 @@ namespace geometry4SharpTests.mesh_selection
 
             return mesh;
         }
+        #endregion
 
         [Fact]
         public void NTMeshConnectedComponents_Separate_Cube()

--- a/geometry4Sharp_netstandard.csproj
+++ b/geometry4Sharp_netstandard.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.1.0</Version>
+    <Version>1.1.2.0</Version>
     <Title>geometry4Sharp</Title>
     <Authors></Authors>
     <Company></Company>

--- a/geometry4Sharp_netstandard.csproj
+++ b/geometry4Sharp_netstandard.csproj
@@ -41,9 +41,4 @@
     <None Include="LICENSE" Pack="true" PackagePath="LICENSE.txt" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.9.3" />
-  </ItemGroup>
-
 </Project>

--- a/mesh_ops/NTSimpleHoleFiller.cs
+++ b/mesh_ops/NTSimpleHoleFiller.cs
@@ -78,6 +78,21 @@ namespace g4
 
         }
 
+        public static void FillHoles(NTMesh3 mesh, bool onlyThreeVerticesLoops = false)
+        {
+            var loops = new NTMeshBoundaryLoops(mesh);
 
+            foreach (var loop in loops)
+            {
+                if (onlyThreeVerticesLoops && loop.VertexCount != 3)
+                {
+                    continue;
+                }
+
+                var filler = new NTSimpleHoleFiller(mesh, loop);
+                filler.Fill();
+            }
+
+        }
     }
 }


### PR DESCRIPTION
Adding a new parameter `public Func<Triangle3d, Triangle3d, bool> AdjacencyFilterF` to **NTMeshConnectedComponents**. It enables filtering out connections between triangles by specifying a function that takes both triangles as input.