### PR TITLE
Implementing NTMesh3.CollapseEdge()

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("1.1.3.0")]
-[assembly: AssemblyFileVersion("1.1.3.0")]
+[assembly: AssemblyVersion("1.1.4.0")]
+[assembly: AssemblyFileVersion("1.1.4.0")]
 
 #endif

--- a/geometry4SharpTests/mesh/NTMesh3Tests.cs
+++ b/geometry4SharpTests/mesh/NTMesh3Tests.cs
@@ -71,6 +71,16 @@ namespace geometry4SharpTests.mesh
             var mesh = TestData1();
             mesh.CollapseEdge(1, 0, out var _);
             mesh.TriangleCount.ShouldBe(0);
+
+            var vertexIndices = mesh.VertexIndices().ToList();
+            var edgeIndices = mesh.EdgeIndices().ToList();
+            var triangleIndices = mesh.TriangleIndices().ToList();
+
+            vertexIndices.Count.ShouldBe(0);
+            edgeIndices.Count.ShouldBe(0);
+            triangleIndices.Count.ShouldBe(0);
+
+            mesh.CheckValidity(FailMode.ReturnOnly).ShouldBe(true);
         }
 
         [Fact]
@@ -79,6 +89,53 @@ namespace geometry4SharpTests.mesh
             var mesh = TestData2();
             mesh.CollapseEdge(1, 0, out var _);
             mesh.TriangleCount.ShouldBe(1);
+
+            var vertexIndices = mesh.VertexIndices().ToList();
+            var edgeIndices = mesh.EdgeIndices().ToList();
+            var triangleIndices = mesh.TriangleIndices().ToList();
+
+            var vertexRefcounts = vertexIndices.Select(mesh.vertices_refcount.refCount).ToList();
+
+            vertexIndices.Count.ShouldBe(3);
+            edgeIndices.Count.ShouldBe(3);
+            triangleIndices.Count.ShouldBe(1);
+
+            var vertexEdges = vertexIndices.Select(vid => mesh.vertex_edges.ValueItr(vid).ToList()).ToList();
+            var edgeTriangles = edgeIndices.Select(eid => mesh.edge_triangles.ValueItr(eid).ToList()).ToList();
+
+            vertexEdges.Count.ShouldBe(3);
+            edgeTriangles.Count.ShouldBe(3);
+
+            var edgesV0 = vertexEdges[0];
+            var edgesV1 = vertexEdges[1];
+            var edgesV2 = vertexEdges[2];
+
+            var trianglesE0 = edgeTriangles[0];
+            var trianglesE1 = edgeTriangles[1];
+            var trianglesE2 = edgeTriangles[2];
+
+            edgesV0.Count.ShouldBe(2);
+            edgesV1.Count.ShouldBe(2);
+            edgesV2.Count.ShouldBe(2);
+
+            trianglesE0.Count.ShouldBe(1);
+            trianglesE1.Count.ShouldBe(1);
+            trianglesE2.Count.ShouldBe(1);
+
+            edgesV0.Contains(4).ShouldBe(true);
+            edgesV0.Contains(5).ShouldBe(true);
+
+            edgesV1.Contains(4).ShouldBe(true);
+            edgesV1.Contains(6).ShouldBe(true);
+
+            edgesV2.Contains(5).ShouldBe(true);
+            edgesV2.Contains(6).ShouldBe(true);
+
+            trianglesE0.Contains(2);
+            trianglesE1.Contains(2);
+            trianglesE2.Contains(2);
+
+            mesh.CheckValidity(FailMode.Throw).ShouldBe(true);
         }
 
         [Fact]
@@ -87,7 +144,89 @@ namespace geometry4SharpTests.mesh
             var mesh = TestData3();
             mesh.CollapseEdge(1, 0, out var _);
             mesh.TriangleCount.ShouldBe(3);
-        }
 
+            var vertexIndices = mesh.VertexIndices().ToList();
+            var edgeIndices = mesh.EdgeIndices().ToList();
+            var triangleIndices = mesh.TriangleIndices().ToList();
+
+            vertexIndices.Count.ShouldBe(6);
+            edgeIndices.Count.ShouldBe(8);
+            triangleIndices.Count.ShouldBe(3);
+
+            var vertexEdges = vertexIndices.Select(vid => mesh.vertex_edges.ValueItr(vid).ToList()).ToList();
+            var edgeTriangles = edgeIndices.Select(eid => mesh.edge_triangles.ValueItr(eid).ToList()).ToList();
+
+            vertexEdges.Count.ShouldBe(6);
+            edgeTriangles.Count.ShouldBe(8);
+
+            var edgesV0 = vertexEdges[0];
+            var edgesV1 = vertexEdges[1];
+            var edgesV2 = vertexEdges[2];
+            var edgesV3 = vertexEdges[3];
+            var edgesV4 = vertexEdges[4];
+            var edgesV5 = vertexEdges[5];
+
+            var trianglesE0 = edgeTriangles[0];
+            var trianglesE1 = edgeTriangles[1];
+            var trianglesE2 = edgeTriangles[2];
+            var trianglesE3 = edgeTriangles[3];
+            var trianglesE4 = edgeTriangles[4];
+            var trianglesE5 = edgeTriangles[5];
+            var trianglesE6 = edgeTriangles[6];
+            var trianglesE7 = edgeTriangles[7];
+
+            edgesV0.Count.ShouldBe(5);
+            edgesV1.Count.ShouldBe(2);
+            edgesV2.Count.ShouldBe(2);
+            edgesV3.Count.ShouldBe(3);
+            edgesV4.Count.ShouldBe(2);
+            edgesV5.Count.ShouldBe(2);
+
+            trianglesE0.Count.ShouldBe(1);
+            trianglesE1.Count.ShouldBe(1);
+            trianglesE2.Count.ShouldBe(1);
+            trianglesE3.Count.ShouldBe(1);
+            trianglesE4.Count.ShouldBe(1);
+            trianglesE5.Count.ShouldBe(1);
+            trianglesE6.Count.ShouldBe(1);
+            trianglesE7.Count.ShouldBe(2);
+
+            edgesV0.Contains(4).ShouldBe(true);
+            edgesV0.Contains(5).ShouldBe(true);
+            edgesV0.Contains(9).ShouldBe(true);
+            edgesV0.Contains(10).ShouldBe(true);
+            edgesV0.Contains(12).ShouldBe(true);
+
+            edgesV1.Contains(4).ShouldBe(true);
+            edgesV1.Contains(6).ShouldBe(true);
+
+            edgesV2.Contains(5).ShouldBe(true);
+            edgesV2.Contains(6).ShouldBe(true);
+
+            edgesV3.Contains(8).ShouldBe(true);
+            edgesV3.Contains(11).ShouldBe(true);
+            edgesV3.Contains(12).ShouldBe(true);
+
+            edgesV4.Contains(8).ShouldBe(true);
+            edgesV4.Contains(9).ShouldBe(true);
+
+            edgesV5.Contains(10).ShouldBe(true);
+            edgesV5.Contains(11).ShouldBe(true);
+
+            trianglesE0.Contains(2);
+            trianglesE1.Contains(2);
+            trianglesE2.Contains(2);
+
+            trianglesE3.Contains(3);
+            trianglesE4.Contains(3);
+
+            trianglesE5.Contains(4);
+            trianglesE6.Contains(4);
+            
+            trianglesE7.Contains(3);
+            trianglesE7.Contains(4);
+
+            mesh.CheckValidity(FailMode.ReturnOnly).ShouldBe(true);
+        }
     }
 }

--- a/geometry4SharpTests/mesh/NTMesh3Tests.cs
+++ b/geometry4SharpTests/mesh/NTMesh3Tests.cs
@@ -66,7 +66,7 @@ namespace geometry4SharpTests.mesh
         #endregion
 
         [Fact]
-        public void Test1()
+        public void NTMesh3_CollapseEdge_Test1()
         {
             var mesh = TestData1();
             mesh.CollapseEdge(1, 0, out var _);
@@ -74,7 +74,7 @@ namespace geometry4SharpTests.mesh
         }
 
         [Fact]
-        public void Test2()
+        public void NTMesh3_CollapseEdge_Test2()
         {
             var mesh = TestData2();
             mesh.CollapseEdge(1, 0, out var _);
@@ -82,7 +82,7 @@ namespace geometry4SharpTests.mesh
         }
 
         [Fact]
-        public void Test3()
+        public void NTMesh3_CollapseEdge_Test3()
         {
             var mesh = TestData3();
             mesh.CollapseEdge(1, 0, out var _);

--- a/geometry4SharpTests/mesh/NTMesh3Tests.cs
+++ b/geometry4SharpTests/mesh/NTMesh3Tests.cs
@@ -1,0 +1,93 @@
+using g4;
+using Shouldly;
+
+namespace geometry4SharpTests.mesh
+{
+    public class NTMesh3Tests
+    {
+        #region Test Data
+
+        private static NTMesh3 TestData1()
+        {
+            var mesh = new NTMesh3();
+
+            var a = mesh.AppendVertex(new Vector3d(0.0, 1.0, 0.0));
+            var b = mesh.AppendVertex(new Vector3d(0.0, -1.0, 0.0));
+            var c = mesh.AppendVertex(new Vector3d(-1.0, 0.0, 0.0));
+            var d = mesh.AppendVertex(new Vector3d(1.0, 0.0, 0.0));
+
+            mesh.AppendTriangle(a, b, d);
+            mesh.AppendTriangle(a, c, b);
+
+            return mesh;
+        }
+
+        private static NTMesh3 TestData2()
+        {
+            var mesh = new NTMesh3();
+
+            var a = mesh.AppendVertex(new Vector3d(0.0, 1.0, 0.0));
+            var b = mesh.AppendVertex(new Vector3d(0.0, -1.0, 0.0));
+            var c = mesh.AppendVertex(new Vector3d(-1.0, 0.0, 0.0));
+            var d = mesh.AppendVertex(new Vector3d(1.0, 0.0, 0.0));
+            var e = mesh.AppendVertex(new Vector3d(-0.5, 1.5, 0.0));
+
+            mesh.AppendTriangle(a, b, d);
+            mesh.AppendTriangle(a, c, b);
+            mesh.AppendTriangle(a, e, c);
+
+            return mesh;
+        }
+
+        private static NTMesh3 TestData3()
+        {
+            var mesh = new NTMesh3();
+
+            var a = mesh.AppendVertex(new Vector3d(0.0, 1.0, 0.0));
+            var b = mesh.AppendVertex(new Vector3d(0.0, -1.0, 0.0));
+            var c = mesh.AppendVertex(new Vector3d(-1.0, 0.0, 0.0));
+            var d = mesh.AppendVertex(new Vector3d(1.0, 0.0, 0.0));
+            var e = mesh.AppendVertex(new Vector3d(-0.5, 1.5, 0.0));
+
+            var x = mesh.AppendVertex(new Vector3d(0.0, 0.0, 1.0));
+            var y = mesh.AppendVertex(new Vector3d(0.0, 1.0, 1.0));
+            var z = mesh.AppendVertex(new Vector3d(0.0, -1.0, 1.0));
+
+            mesh.AppendTriangle(a, b, d);
+            mesh.AppendTriangle(a, c, b);
+            mesh.AppendTriangle(a, e, c);
+
+            mesh.AppendTriangle(a, x, y);
+            mesh.AppendTriangle(b, z, x);
+
+            return mesh;
+        }
+
+        #endregion
+
+        [Fact]
+        public void Test1()
+        {
+            var mesh = TestData1();
+            mesh.CollapseEdge(1, 0, out var _);
+            mesh.TriangleCount.ShouldBe(0);
+        }
+
+        [Fact]
+        public void Test2()
+        {
+            var mesh = TestData2();
+            mesh.CollapseEdge(1, 0, out var _);
+            mesh.TriangleCount.ShouldBe(1);
+        }
+
+        [Fact]
+        public void Test3()
+        {
+            var mesh = TestData3();
+            mesh.CollapseEdge(1, 0, out var _);
+            mesh.TriangleCount.ShouldBe(3);
+        }
+
+    }
+}

--- a/geometry4SharpTests/mesh/NTMesh3Tests.cs
+++ b/geometry4SharpTests/mesh/NTMesh3Tests.cs
@@ -69,8 +69,11 @@ namespace geometry4SharpTests.mesh
         public void NTMesh3_CollapseEdge_Test1()
         {
             var mesh = TestData1();
-            mesh.CollapseEdge(1, 0, out var _);
+            mesh.CollapseEdge(1, 0, out var collapseInfo);
             mesh.TriangleCount.ShouldBe(0);
+
+            collapseInfo.eRemoved.Count.ShouldBe(5);
+            collapseInfo.tRemoved.Count.ShouldBe(2);
 
             var vertexIndices = mesh.VertexIndices().ToList();
             var edgeIndices = mesh.EdgeIndices().ToList();
@@ -87,8 +90,11 @@ namespace geometry4SharpTests.mesh
         public void NTMesh3_CollapseEdge_Test2()
         {
             var mesh = TestData2();
-            mesh.CollapseEdge(1, 0, out var _);
+            mesh.CollapseEdge(1, 0, out var collapseInfo);
             mesh.TriangleCount.ShouldBe(1);
+
+            collapseInfo.eRemoved.Count.ShouldBe(4);
+            collapseInfo.tRemoved.Count.ShouldBe(2);
 
             var vertexIndices = mesh.VertexIndices().ToList();
             var edgeIndices = mesh.EdgeIndices().ToList();
@@ -135,15 +141,18 @@ namespace geometry4SharpTests.mesh
             trianglesE1.Contains(2);
             trianglesE2.Contains(2);
 
-            mesh.CheckValidity(FailMode.Throw).ShouldBe(true);
+            mesh.CheckValidity(FailMode.ReturnOnly).ShouldBe(true);
         }
 
         [Fact]
         public void NTMesh3_CollapseEdge_Test3()
         {
             var mesh = TestData3();
-            mesh.CollapseEdge(1, 0, out var _);
+            mesh.CollapseEdge(1, 0, out var collapseInfo);
             mesh.TriangleCount.ShouldBe(3);
+
+            collapseInfo.eRemoved.Count.ShouldBe(5);
+            collapseInfo.tRemoved.Count.ShouldBe(2);
 
             var vertexIndices = mesh.VertexIndices().ToList();
             var edgeIndices = mesh.EdgeIndices().ToList();

--- a/geometry4SharpTests/mesh_ops/NTMeshPlaneCutTests.cs
+++ b/geometry4SharpTests/mesh_ops/NTMeshPlaneCutTests.cs
@@ -69,5 +69,35 @@ namespace geometry4SharpTests.mesh_ops
 
             totalArea.ShouldBe(expectedTotalArea, EPS);
         }
+
+        [Theory]
+        [InlineData(0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 16.0)]                            // Splitting cube in half (y-axis)
+        [InlineData(0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 24.0)]                            // Plane is coplanar with top face (same normal as face)
+        [InlineData(0.0, 1.0001, 0.0, 0.0, 1.0, 0.0, 24.0)]                         // Cube is entirely behind the plane
+        [InlineData(0.0, 0.9999999, 0.0, 0.0, 1.0, 0.0, 24.0)]                      // "Only" top face is in front of the plane
+        [InlineData(0.0, -1.0, 0.0, 0.0, 1.0, 0.0, 8.0)]                            // Plane is coplanar with bottom face (opposite normal as face)
+        [InlineData(0.0, -1.0001, 0.0, 0.0, 1.0, 0.0, 0.0)]                         // Cube is entirely in front of the plane
+        [InlineData(0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 16.0)]                            // Splitting cube in half (x-axis)
+        [InlineData(0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 16.0)]                            // Splitting cube in half (z-axis)
+        [InlineData(0.1, 0.1, 0.1, 0.57735027, 0.57735027, 0.57735027, 18.84)]       // Splitting cube with displaced/rotated plane
+        public void NTMeshPlaneCut_CutAndFillHoles_Cube(double cx, double cy, double cz,
+            double nx, double ny, double nz, double expectedTotalArea)
+        {
+            const double EPS = 1e-3;
+            var mesh = CreateCube();
+
+            var planeCenter = new Vector3d(cx, cy, cz);
+            var planeNormal = new Vector3d(nx, ny, nz).Normalized;
+
+            var planeCut = new NTMeshPlaneCut(mesh, planeCenter, planeNormal);
+            planeCut.Cut();
+            planeCut.FillHoles();
+
+            var totalArea = mesh
+                .TriangleIndices()
+                .Sum(mesh.GetTriArea);
+
+            totalArea.ShouldBe(expectedTotalArea, EPS);
+        }
     }
 }

--- a/geometry4SharpTests/mesh_ops/NTMeshPlaneCutTests.cs
+++ b/geometry4SharpTests/mesh_ops/NTMeshPlaneCutTests.cs
@@ -63,6 +63,8 @@ namespace geometry4SharpTests.mesh_ops
             var planeCut = new NTMeshPlaneCut(mesh, planeCenter, planeNormal);
             planeCut.Cut();
 
+            mesh.CheckValidity(FailMode.ReturnOnly).ShouldBe(true);
+
             var totalArea = mesh
                 .TriangleIndices()
                 .Sum(mesh.GetTriArea);
@@ -92,6 +94,8 @@ namespace geometry4SharpTests.mesh_ops
             var planeCut = new NTMeshPlaneCut(mesh, planeCenter, planeNormal);
             planeCut.Cut();
             planeCut.FillHoles();
+
+            mesh.CheckValidity(FailMode.ReturnOnly).ShouldBe(true);
 
             var totalArea = mesh
                 .TriangleIndices()

--- a/geometry4Sharp_netstandard.csproj
+++ b/geometry4Sharp_netstandard.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.3.0</Version>
+    <Version>1.1.4.0</Version>
     <Title>geometry4Sharp</Title>
     <Authors></Authors>
     <Company></Company>

--- a/geometry4Sharp_netstandard.csproj
+++ b/geometry4Sharp_netstandard.csproj
@@ -41,4 +41,11 @@
     <None Include="LICENSE" Pack="true" PackagePath="LICENSE.txt" />
   </ItemGroup>
 
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>geometry4SharpTests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/mesh/NTMesh3.cs
+++ b/mesh/NTMesh3.cs
@@ -6,19 +6,18 @@ using System.Security.Cryptography;
 
 namespace g4
 {
-
-	//
-	// NTMesh3 is a variant of DMesh3 that supports non-manifold mesh topology. 
-	// See DMesh3 comments for most details. 
-	// Main change is that edges buffer only stores 2-tuple vertex pairs.
-	// Each edge can be connected to arbitrary number of triangle, which are
-	// stored in edge_triangles
-	//
-	// per-vertex UVs have been removed (perhaps temporarily)
-	//
-	// Currently poke-face and split-edge are supported, but not collapse or flip.
-	// 
-	public partial class NTMesh3 : IDeformableMesh
+    //
+    // NTMesh3 is a variant of DMesh3 that supports non-manifold mesh topology. 
+    // See DMesh3 comments for most details. 
+    // Main change is that edges buffer only stores 2-tuple vertex pairs.
+    // Each edge can be connected to arbitrary number of triangle, which are
+    // stored in edge_triangles
+    //
+    // per-vertex UVs have been removed (perhaps temporarily)
+    //
+    // Currently poke-face and split-edge are supported, but not collapse or flip.
+    // 
+    public partial class NTMesh3 : IDeformableMesh
 	{
 		public const int InvalidID = -1;
 		public const int NonManifoldID = -2;
@@ -815,7 +814,7 @@ namespace g4
 				foreach (int tID in tris)
 				{
 					MeshResult result = RemoveTriangle(tID, false, bPreserveManifold);
-					if (result != MeshResult.Ok)
+                    if (result != MeshResult.Ok)
 						return result;
 				}
 			}
@@ -1639,7 +1638,6 @@ namespace g4
             return MeshResult.Ok;
         }
 
-
         public struct PokeTriangleInfo
         {
             public int new_vid;
@@ -2237,6 +2235,130 @@ namespace g4
             flip.v0 = a; flip.v1 = b;
             flip.ov0 = c; flip.ov1 = d;
             flip.t0 = t0; flip.t1 = t1;
+
+            updateTimeStamp(true);
+            return MeshResult.Ok;
+        }
+
+
+        public struct EdgeCollapseInfo
+        {
+            public int vKept;
+            public int vRemoved;
+
+            public int eCollapsed;              // edge we collapsed
+            public List<int> tRemoved;			// tris we removed (second may be invalid)
+            public List<int> eRemoved;			// edges we removed (second may be invalid)
+        }
+
+
+        public MeshResult CollapseEdge(int vKeep, int vRemove, out EdgeCollapseInfo collapse)
+        {
+            collapse = new EdgeCollapseInfo();
+			collapse.tRemoved = new List<int>();
+			collapse.eRemoved = new List<int>();
+
+            if (IsVertex(vKeep) == false || IsVertex(vRemove) == false)
+                return MeshResult.Failed_NotAnEdge;
+
+            int b = vKeep;      // renaming for sanity. We remove a and keep b
+            int a = vRemove;
+
+            int eab = find_edge(a, b);
+            if (eab == InvalidID)
+                return MeshResult.Failed_NotAnEdge;
+
+			collapse.vKept = vKeep;
+			collapse.vRemoved = vRemove;
+			collapse.eCollapsed = eab;
+
+			// 1) remove edge ab from vtx b
+			vertex_edges.Remove(b, eab);
+
+			// 2) find all edges between a and c (c != b); remove edge reference from c
+			// 3) find all triangles from a without b; for those triangles, replace a by b
+			// 4) for the edges eac without a triangle with b, replace a by b
+			var edgeNewTris = new Dictionary<int, List<int>>();
+			foreach (var eac in VtxEdgesItr(a))
+			{
+				edgeNewTris[eac] = new List<int>();
+
+				if (eac == eab)
+				{
+					continue;
+				}
+
+				var eacIndices = GetEdgeV(eac);
+				var c = IndexUtil.find_edge_other_v(eacIndices, a);
+
+                // Might not be necessary
+                if (c == b) 
+				{
+					continue;
+				}
+
+				// eac is an edge from a without b
+				vertex_edges.Remove(c, eac);
+
+				bool hasTriangleInCommon = false;
+                foreach (var tac in EdgeTrianglesItr(eac))
+				{
+					var tacIndices = GetTriangle(tac);
+					var d = IndexUtil.find_tri_other_vtx(a, c, tacIndices);
+
+					if (d == b)
+					{
+						hasTriangleInCommon = true;
+						break;
+					}
+
+					// tac is a triangle from a without b
+					replace_tri_vertex(tac, a, b);
+                    vertices_refcount.increment(b);
+                    vertices_refcount.decrement(a);
+					edgeNewTris[eac].Add(tac);
+                }
+
+                if (!hasTriangleInCommon)
+				{
+					// TODO: check if edge between b and c already exist
+                    replace_edge_vertex(eac, a, b);
+                }
+            }
+
+			vertex_edges.Clear(a);
+            vertices_refcount.decrement(a, (short)vertices_refcount.refCount(a));
+			foreach (var tab in EdgeTrianglesItr(eab))
+			{
+				var tabIndices = GetTriangle(tab);
+				var c = IndexUtil.find_tri_other_vtx(a, b, tabIndices);
+				var eac = find_edge_from_tri(a, c, tab);
+				var ebc = find_edge_from_tri(b, c, tab);
+                var tabEdges = GetTriEdges(tab);
+
+                triangles_refcount.decrement(tab);
+				vertices_refcount.decrement(b);
+				vertices_refcount.decrement(c);
+                //Debug.Assert(triangles_refcount.isValid(tab) == false);
+
+				edges_refcount.decrement(tabEdges.a);
+				edges_refcount.decrement(tabEdges.b);
+				edges_refcount.decrement(tabEdges.c);
+                //Debug.Assert(edges_refcount.isValid(tabEdges.a) == false);
+                //Debug.Assert(edges_refcount.isValid(tabEdges.b) == false);
+                //Debug.Assert(edges_refcount.isValid(tabEdges.c) == false);
+
+				remove_edge_triangle(eac, tab);
+
+				foreach (var newTri in edgeNewTris[eac])
+				{
+					add_edge_triangle(ebc, newTri);
+					replace_triangle_edge(newTri, eac, ebc);
+                }
+
+				collapse.tRemoved.Add(tab);
+                collapse.tRemoved.Add(eac);
+            }
 
             updateTimeStamp(true);
             return MeshResult.Ok;

--- a/mesh/NTMesh3.cs
+++ b/mesh/NTMesh3.cs
@@ -2248,8 +2248,8 @@ namespace g4
             public int vRemoved;
 
             public int eCollapsed;              // edge we collapsed
-            public List<int> tRemoved;			// tris we removed (second may be invalid)
-            public List<int> eRemoved;			// edges we removed (second may be invalid)
+            public List<int> tRemoved;			// tris we removed
+            public List<int> eRemoved;			// edges we removed
         }
 
 
@@ -2344,6 +2344,7 @@ namespace g4
                         if (edge_triangles.Count(eac) == 0)
                         {
                             edges_refcount.decrement(eac);
+                            collapse.eRemoved.Add(eac);
                         }
                     }
                 }
@@ -2357,8 +2358,9 @@ namespace g4
             
 			// Removing reference to edge ab
 			edges_refcount.decrement(eab);
+            collapse.eRemoved.Add(eab);
 
-            // 5) remove all triangles containing eac
+            // 5) remove all triangles containing eab
             foreach (var tab in EdgeTrianglesItr(eab))
 			{
 				var tabIndices = GetTriangle(tab);
@@ -2368,6 +2370,8 @@ namespace g4
                 var vertices = GetTriangle(tab);
 
                 triangles_refcount.decrement(tab);
+                collapse.tRemoved.Add(tab);
+                
 				vertices_refcount.decrement(b);
 				vertices_refcount.decrement(c);
 
@@ -2376,22 +2380,21 @@ namespace g4
 				remove_edge_triangle(eac, tab);
                 remove_edge_triangle(ebc, tab);
 
-				// removing isolated edges
-				if (edge_triangles.Count(eac) == 0)
+                // removing isolated edges
+                if (edge_triangles.Count(eac) == 0)
 				{
                     edges_refcount.decrement(eac);
-				}
-				if (edge_triangles.Count(ebc) == 0)
+                    collapse.eRemoved.Add(eac);
+                }
+                if (edge_triangles.Count(ebc) == 0)
 				{
                     vertex_edges.Remove(b, ebc);
                     vertex_edges.Remove(c, ebc);
                     edges_refcount.decrement(ebc);
+                    collapse.eRemoved.Add(ebc);
                 }
 
-                collapse.tRemoved.Add(tab);
-                collapse.tRemoved.Add(eac);
-
-				// removing isolated vertices
+                // removing isolated vertices
                 if (vertices_refcount.refCount(vertices.a) == 1)
                 {
                     vertices_refcount.decrement(vertices.a);

--- a/mesh/NTMesh3.cs
+++ b/mesh/NTMesh3.cs
@@ -6,18 +6,18 @@ using System.Security.Cryptography;
 
 namespace g4
 {
-    //
-    // NTMesh3 is a variant of DMesh3 that supports non-manifold mesh topology. 
-    // See DMesh3 comments for most details. 
-    // Main change is that edges buffer only stores 2-tuple vertex pairs.
-    // Each edge can be connected to arbitrary number of triangle, which are
-    // stored in edge_triangles
-    //
-    // per-vertex UVs have been removed (perhaps temporarily)
-    //
-    // Currently poke-face and split-edge are supported, but not collapse or flip.
-    // 
-    public partial class NTMesh3 : IDeformableMesh
+	//
+	// NTMesh3 is a variant of DMesh3 that supports non-manifold mesh topology. 
+	// See DMesh3 comments for most details. 
+	// Main change is that edges buffer only stores 2-tuple vertex pairs.
+	// Each edge can be connected to arbitrary number of triangle, which are
+	// stored in edge_triangles
+	//
+	// per-vertex UVs have been removed (perhaps temporarily)
+	//
+	// Currently poke-face and split-edge are supported, but not collapse or flip.
+	// 
+	public partial class NTMesh3 : IDeformableMesh
 	{
 		public const int InvalidID = -1;
 		public const int NonManifoldID = -2;
@@ -26,24 +26,25 @@ namespace g4
 		public static readonly Index3i InvalidTriangle = new Index3i(InvalidID, InvalidID, InvalidID);
 		public static readonly Index2i InvalidEdge = new Index2i(InvalidID, InvalidID);
 
-		RefCountVector vertices_refcount;
 		DVector<double> vertices;
 		DVector<float> normals;
 		DVector<float> colors;
 
-		SmallListSet vertex_edges;
-
-		RefCountVector triangles_refcount;
 		DVector<int> triangles;
-		DVector<int> triangle_edges;
-		DVector<int> triangle_groups;
+        DVector<int> edges;
+        DVector<int> triangle_groups;
         DVector<int> vertex_groups;
 
-        RefCountVector edges_refcount;
-		DVector<int> edges;
-		SmallListSet edge_triangles;
 
-		int timestamp = 0;
+        internal SmallListSet vertex_edges;
+        internal SmallListSet edge_triangles;
+        internal DVector<int> triangle_edges;
+
+        internal RefCountVector vertices_refcount;
+        internal RefCountVector triangles_refcount;
+        internal RefCountVector edges_refcount;
+
+        int timestamp = 0;
 		int shape_timestamp = 0;
 
 		int max_group_id = 0;
@@ -2307,10 +2308,13 @@ namespace g4
 					}
 
                     // 3) tac is a triangle from a without b
-                    replace_tri_vertex(tac, a, b);
-                    vertices_refcount.increment(b);
-                    vertices_refcount.decrement(a);
-					eacTrisWithoutB.Add(tac);
+                    if (replace_tri_vertex(tac, a, b) != -1)
+					{
+                        vertices_refcount.increment(b);
+                        vertices_refcount.decrement(a);
+                    }
+
+                    eacTrisWithoutB.Add(tac);
                 }
 
                 if (eacTrisWithoutB.Count > 0)
@@ -2331,6 +2335,15 @@ namespace g4
                         {
                             add_edge_triangle(ebc, tac);
                             replace_triangle_edge(tac, eac, ebc);
+							remove_edge_triangle(eac, tac);
+                        }
+
+						// Removing eac if it is isolated
+						// It might not be, if there is an abc triangle
+						vertex_edges.Remove(c, eac);
+                        if (edge_triangles.Count(eac) == 0)
+                        {
+                            edges_refcount.decrement(eac);
                         }
                     }
                 }
@@ -2341,29 +2354,61 @@ namespace g4
 			{
                 vertices_refcount.decrement(a, (short)vertices_refcount.refCount(a));
             }
+            
+			// Removing reference to edge ab
+			edges_refcount.decrement(eab);
 
-			// 5) remove all triangles containing eac
+            // 5) remove all triangles containing eac
             foreach (var tab in EdgeTrianglesItr(eab))
 			{
 				var tabIndices = GetTriangle(tab);
 				var c = IndexUtil.find_tri_other_vtx(a, b, tabIndices);
 				var eac = find_edge_from_tri(a, c, tab);
                 var ebc = find_edge_from_tri(b, c, tab);
+                var vertices = GetTriangle(tab);
 
                 triangles_refcount.decrement(tab);
 				vertices_refcount.decrement(b);
 				vertices_refcount.decrement(c);
-
-				edges_refcount.decrement(eab);
-				edges_refcount.decrement(eac);
 
 				vertex_edges.Remove(c, eac);
 
 				remove_edge_triangle(eac, tab);
                 remove_edge_triangle(ebc, tab);
 
-				collapse.tRemoved.Add(tab);
+				// removing isolated edges
+				if (edge_triangles.Count(eac) == 0)
+				{
+                    edges_refcount.decrement(eac);
+				}
+				if (edge_triangles.Count(ebc) == 0)
+				{
+                    vertex_edges.Remove(b, ebc);
+                    vertex_edges.Remove(c, ebc);
+                    edges_refcount.decrement(ebc);
+                }
+
+                collapse.tRemoved.Add(tab);
                 collapse.tRemoved.Add(eac);
+
+				// removing isolated vertices
+                if (vertices_refcount.refCount(vertices.a) == 1)
+                {
+                    vertices_refcount.decrement(vertices.a);
+                    vertex_edges.Clear(vertices.a);
+                }
+
+                if (vertices_refcount.refCount(vertices.b) == 1)
+                {
+                    vertices_refcount.decrement(vertices.b);
+                    vertex_edges.Clear(vertices.b);
+                }
+
+                if (vertices_refcount.refCount(vertices.c) == 1)
+                {
+                    vertices_refcount.decrement(vertices.c);
+                    vertex_edges.Clear(vertices.c);
+                }
             }
 
             updateTimeStamp(true);

--- a/mesh/NTMesh3.cs
+++ b/mesh/NTMesh3.cs
@@ -997,8 +997,8 @@ namespace g4
 		{
 			if ( vertices_refcount.isValid(vID) ) {
 				var result = new List<int>();
-				foreach (int eid in vertex_edges.ValueItr(vID)) {
-					if (edge_triangles.Count(eid) == 1)
+                foreach (int eid in vertex_edges.ValueItr(vID)) {
+                    if (edge_triangles.Count(eid) == 1)
 						result.Add(eid);
 				}
 				return result;
@@ -1554,7 +1554,7 @@ namespace g4
             // look up primary edge & triangle
             int eab_i = 2 * eab;
             int a = edges[eab_i], b = edges[eab_i + 1];
-
+			
             List<int> triangles = new List<int>(edge_triangles.ValueItr(eab));
             if (triangles.Count < 1)
                 return MeshResult.Failed_BrokenTopology;
@@ -2275,14 +2275,11 @@ namespace g4
 			// 1) remove edge ab from vtx b
 			vertex_edges.Remove(b, eab);
 
-			// 2) find all edges between a and c (c != b); remove edge reference from c
+			// 2) find all edges between a and c (c != b)
 			// 3) find all triangles from a without b; for those triangles, replace a by b
-			// 4) for the edges eac without a triangle with b, replace a by b
-			var edgeNewTris = new Dictionary<int, List<int>>();
-			foreach (var eac in VtxEdgesItr(a))
+			// 4) for the edges eac with a triangle without b, replace a by b
+            foreach (var eac in VtxEdgesItr(a))
 			{
-				edgeNewTris[eac] = new List<int>();
-
 				if (eac == eab)
 				{
 					continue;
@@ -2297,10 +2294,8 @@ namespace g4
 					continue;
 				}
 
-				// eac is an edge from a without b
-				vertex_edges.Remove(c, eac);
-
-				bool hasTriangleInCommon = false;
+				// 2) eac is an edge from a without b
+				var eacTrisWithoutB = new List<int>();
                 foreach (var tac in EdgeTrianglesItr(eac))
 				{
 					var tacIndices = GetTriangle(tac);
@@ -2308,53 +2303,64 @@ namespace g4
 
 					if (d == b)
 					{
-						hasTriangleInCommon = true;
-						break;
+						continue;
 					}
 
-					// tac is a triangle from a without b
-					replace_tri_vertex(tac, a, b);
+                    // 3) tac is a triangle from a without b
+                    replace_tri_vertex(tac, a, b);
                     vertices_refcount.increment(b);
                     vertices_refcount.decrement(a);
-					edgeNewTris[eac].Add(tac);
+					eacTrisWithoutB.Add(tac);
                 }
 
-                if (!hasTriangleInCommon)
+                if (eacTrisWithoutB.Count > 0)
 				{
-					// TODO: check if edge between b and c already exist
-                    replace_edge_vertex(eac, a, b);
+					// 4) eac has a triangle without b
+					var ebc = find_edge(b, c);
+					if (ebc == InvalidID)
+					{
+						// No existing edge between b and c; eac becomes ebc
+                        replace_edge_vertex(eac, a, b);
+                        vertex_edges.Insert(b, eac);
+                    }
+					else
+					{
+						// There is an existing edge between b and c, so we add all triangles
+						// without b to it and replace eac by ebc in them
+                        foreach (var tac in eacTrisWithoutB)
+                        {
+                            add_edge_triangle(ebc, tac);
+                            replace_triangle_edge(tac, eac, ebc);
+                        }
+                    }
                 }
             }
 
 			vertex_edges.Clear(a);
-            vertices_refcount.decrement(a, (short)vertices_refcount.refCount(a));
-			foreach (var tab in EdgeTrianglesItr(eab))
+			if (vertices_refcount.refCount(a) > 0)	// This might always be zero here
+			{
+                vertices_refcount.decrement(a, (short)vertices_refcount.refCount(a));
+            }
+
+			// 5) remove all triangles containing eac
+            foreach (var tab in EdgeTrianglesItr(eab))
 			{
 				var tabIndices = GetTriangle(tab);
 				var c = IndexUtil.find_tri_other_vtx(a, b, tabIndices);
 				var eac = find_edge_from_tri(a, c, tab);
-				var ebc = find_edge_from_tri(b, c, tab);
-                var tabEdges = GetTriEdges(tab);
+                var ebc = find_edge_from_tri(b, c, tab);
 
                 triangles_refcount.decrement(tab);
 				vertices_refcount.decrement(b);
 				vertices_refcount.decrement(c);
-                //Debug.Assert(triangles_refcount.isValid(tab) == false);
 
-				edges_refcount.decrement(tabEdges.a);
-				edges_refcount.decrement(tabEdges.b);
-				edges_refcount.decrement(tabEdges.c);
-                //Debug.Assert(edges_refcount.isValid(tabEdges.a) == false);
-                //Debug.Assert(edges_refcount.isValid(tabEdges.b) == false);
-                //Debug.Assert(edges_refcount.isValid(tabEdges.c) == false);
+				edges_refcount.decrement(eab);
+				edges_refcount.decrement(eac);
+
+				vertex_edges.Remove(c, eac);
 
 				remove_edge_triangle(eac, tab);
-
-				foreach (var newTri in edgeNewTris[eac])
-				{
-					add_edge_triangle(ebc, newTri);
-					replace_triangle_edge(newTri, eac, ebc);
-                }
+                remove_edge_triangle(ebc, tab);
 
 				collapse.tRemoved.Add(tab);
                 collapse.tRemoved.Add(eac);
@@ -2694,6 +2700,6 @@ namespace g4
 			edge_triangles.Insert(eID, t0);
 			edge_triangles.Insert(eID, t1);
 		}
-	}
+    }
 }
 

--- a/mesh_ops/NTMeshPlaneCut.cs
+++ b/mesh_ops/NTMeshPlaneCut.cs
@@ -166,10 +166,9 @@ namespace g4
 				collapse_degenerate_edges(OnCutEdges, ZeroEdges);
 			}
 
-
-			// ok now we extract boundary loops, but restricted
-			// to either the zero-edges we found, or the edges we created! bang!!
-			Func<int, bool> CutEdgeFilterF = (eid) => {
+            // ok now we extract boundary loops, but restricted
+            // to either the zero-edges we found, or the edges we created! bang!!
+            Func<int, bool> CutEdgeFilterF = (eid) => {
 				if (OnCutEdges.Contains(eid) || ZeroEdges.Contains(eid))
 					return true;
 				return false;

--- a/mesh_ops/NTMeshPlaneCut.cs
+++ b/mesh_ops/NTMeshPlaneCut.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 namespace g4
 {
@@ -31,13 +32,13 @@ namespace g4
 		public Vector3d PlaneOrigin;
 		public Vector3d PlaneNormal;
 
-        // a plane cut very near a vertex can result in degenerate edges on the open loops/spans, which 
-        // can cause problems downstream (eg if hole-filling). It is easy for us to collapse these before
-        // we construct the loops.
-        //public bool CollapseDegenerateEdgesOnCut = true;
+		// a plane cut very near a vertex can result in degenerate edges on the open loops/spans, which 
+		// can cause problems downstream (eg if hole-filling). It is easy for us to collapse these before
+		// we construct the loops.
+		public bool CollapseDegenerateEdgesOnCut = true;
 
-        // the min-edge-length if we are collapsing degenerate edges
-        public double DegenerateEdgeTol = MathUtil.ZeroTolerancef;
+		// the min-edge-length if we are collapsing degenerate edges
+		public double DegenerateEdgeTol = MathUtil.ZeroTolerancef;
 
         // if non-null, we will only iterate through these edges
 		//public NTMeshFaceSelection CutFaceSet = null;
@@ -132,7 +133,7 @@ namespace g4
 
 				NTMesh3.EdgeSplitInfo splitInfo;
 				MeshResult result = Mesh.SplitEdge(eid, out splitInfo);
-				if (result != MeshResult.Ok) {
+                if (result != MeshResult.Ok) {
 					throw new Exception("MeshPlaneCut.Cut: failed in SplitEdge");
 					//return false;
 				}
@@ -160,9 +161,10 @@ namespace g4
 			}
 
             // collapse degenerate edges if we got em
-            //if (CollapseDegenerateEdgesOnCut) {
-            //    collapse_degenerate_edges(OnCutEdges, ZeroEdges);
-            //}
+            if (CollapseDegenerateEdgesOnCut)
+			{
+				collapse_degenerate_edges(OnCutEdges, ZeroEdges);
+			}
 
 
 			// ok now we extract boundary loops, but restricted
@@ -191,45 +193,47 @@ namespace g4
 
 		} // Cut()
 
-		//protected void collapse_degenerate_edges(HashSet<int> OnCutEdges, HashSet<int> ZeroEdges)
-		//{
-		//    HashSet<int>[] sets = new HashSet<int>[2] { OnCutEdges, ZeroEdges };
+		protected void collapse_degenerate_edges(HashSet<int> OnCutEdges, HashSet<int> ZeroEdges)
+		{
+			HashSet<int>[] sets = new HashSet<int>[2] { OnCutEdges, ZeroEdges };
 
-		//    double tol2 = DegenerateEdgeTol * DegenerateEdgeTol;
-		//    Vector3d a = Vector3d.Zero, b = Vector3d.Zero;
-		//    int collapsed = 0;
-		//    do {
-		//        collapsed = 0;
-		//        foreach (var edge_set in sets) {
-		//            foreach (int eid in edge_set) {
-		//                if (Mesh.IsEdge(eid) == false)
-		//                    continue;
-		//                Mesh.GetEdgeV(eid, ref a, ref b);
-		//                if (a.DistanceSquared(b) > tol2)
-		//                    continue;
+			double tol2 = DegenerateEdgeTol * DegenerateEdgeTol;
+			Vector3d a = Vector3d.Zero, b = Vector3d.Zero;
+			int collapsed = 0;
+			do
+			{
+				collapsed = 0;
+				foreach (var edge_set in sets)
+				{
+					foreach (int eid in edge_set)
+					{
+						if (Mesh.IsEdge(eid) == false)
+							continue;
+						Mesh.GetEdgeV(eid, ref a, ref b);
+						if (a.DistanceSquared(b) > tol2)
+							continue;
 
-		//                Index2i ev = Mesh.GetEdgeV(eid);
-		//                DMesh3.EdgeCollapseInfo collapseInfo;
-		//                MeshResult result = Mesh.CollapseEdge(ev.a, ev.b, out collapseInfo);
-		//                if (result == MeshResult.Ok)
-		//                    collapsed++;
-		//            }
-		//        }
-		//    } while (collapsed != 0);
-		//}
+						Index2i ev = Mesh.GetEdgeV(eid);
+						NTMesh3.EdgeCollapseInfo collapseInfo;
+						MeshResult result = Mesh.CollapseEdge(ev.a, ev.b, out collapseInfo);
+						if (result == MeshResult.Ok)
+							collapsed++;
+					}
+				}
+			} while (collapsed != 0);
+		}
 
 		/// <summary>
 		/// A quick-and-dirty hole filling. If you want something better,
 		/// process the returned CutLoops yourself.
 		/// </summary>
-		[Obsolete("Degenerate edges collapsing has not been implemented yet; FillHoles results may be incorrect.")]
 		public bool FillHoles(int constantGroupID = -1)
 		{
 			bool bAllOk = true;
 
 			LoopFillTriangles = new List<int[]>(CutLoops.Count);
 
-			foreach ( var loop in CutLoops) {
+            foreach ( var loop in CutLoops) {
 				var filler = new NTSimpleHoleFiller(Mesh, loop);
 				int gid = (constantGroupID >= 0) ? constantGroupID : Mesh.AllocateTriangleGroup();
 				if ( filler.Fill(gid) ) {


### PR DESCRIPTION
Implementing `NTMesh3.CollapseEdge()` to ensure correct results for `NTMeshPlaneCut.FillHoles()`. Adding unit tests for both `NTMesh3.CollapseEdge()` and `NTMeshPlaneCut.FillHoles()`.