### PR TITLE
Exposing internal NTMesh3 Data Structures to Derived Classes

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("1.1.4.0")]
-[assembly: AssemblyFileVersion("1.1.4.0")]
+[assembly: AssemblyVersion("1.1.5.0")]
+[assembly: AssemblyFileVersion("1.1.5.0")]
 
 #endif

--- a/distance/DistRay3Triangle3.cs
+++ b/distance/DistRay3Triangle3.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace g4
+{
+    /// <summary>
+    /// Distance between a 3D Ray and a 3D Triangle.
+    /// Follows the standard WildMagic5 / geometry3Sharp distance query pattern.
+    /// </summary>
+    public class DistRay3Triangle3
+    {
+        Ray3d ray;
+        public Ray3d Ray
+        {
+            get { return ray; }
+            set { ray = value; DistanceSquared = -1.0; }
+        }
+
+        Triangle3d triangle;
+        public Triangle3d Triangle
+        {
+            get { return triangle; }
+            set { triangle = value; DistanceSquared = -1.0; }
+        }
+
+        public double DistanceSquared = -1.0;
+
+        public Vector3d RayClosest;
+        public double RayParameter;
+        public Vector3d TriangleClosest;
+        public Vector3d TriangleBaryCoords;
+
+
+        public DistRay3Triangle3(Ray3d rayIn, Triangle3d triangleIn)
+        {
+            this.ray = rayIn; 
+            this.triangle = triangleIn;
+        }
+
+
+        static public double MinDistance(Ray3d r, Triangle3d t) 
+        {
+            return new DistRay3Triangle3(r, t).Get();
+        }
+
+        static public double MinDistanceRayParam(Ray3d r, Triangle3d t) 
+        {
+            return new DistRay3Triangle3(r, t).Compute().RayParameter;
+        }
+
+
+        public DistRay3Triangle3 Compute() 
+        {
+            GetSquared();
+            return this;
+        }
+
+        public double Get() 
+        {
+            return Math.Sqrt(GetSquared());
+        }
+
+        public double GetSquared()
+        {
+            if (DistanceSquared >= 0)
+                return DistanceSquared;
+
+            Vector3d edge0 = triangle.V1 - triangle.V0;
+            Vector3d edge1 = triangle.V2 - triangle.V0;
+            Vector3d normal = edge0.Cross(edge1);
+            double normalSqLen = normal.LengthSquared;
+
+            // 1. Check if the infinite line intersects the triangle plane
+            if (normalSqLen > MathUtil.ZeroTolerance * MathUtil.ZeroTolerance)
+            {
+                double NdotD = normal.Dot(ray.Direction);
+                if (Math.Abs(NdotD) > MathUtil.ZeroTolerance)
+                {
+                    double t = normal.Dot(triangle.V0 - ray.Origin) / NdotD;
+                    
+                    // If intersection is strictly in front of the ray origin
+                    if (t >= 0)
+                    {
+                        Vector3d hitPt = ray.Origin + t * ray.Direction;
+                        Vector3d bary = ComputeBarycentric(hitPt, triangle.V0, edge0, edge1);
+                        
+                        // Check if the intersection point is inside the triangle
+                        if (bary.x >= -MathUtil.ZeroTolerance && 
+                            bary.y >= -MathUtil.ZeroTolerance && 
+                            bary.z >= -MathUtil.ZeroTolerance)
+                        {
+                            RayClosest = hitPt;
+                            TriangleClosest = hitPt;
+                            RayParameter = t;
+                            TriangleBaryCoords = bary;
+                            DistanceSquared = 0;
+                            return 0;
+                        }
+                    }
+                }
+            }
+
+            // 2. If no direct intersection, the closest point lies on the boundaries.
+            // The boundary of the Triangle consists of its 3 edges.
+            Segment3d seg0 = new Segment3d(triangle.V0, triangle.V1);
+            Segment3d seg1 = new Segment3d(triangle.V1, triangle.V2);
+            Segment3d seg2 = new Segment3d(triangle.V2, triangle.V0);
+
+            double minSqDist = double.MaxValue;
+            Vector3d bestRayPt = Vector3d.Zero;
+            Vector3d bestTriPt = Vector3d.Zero;
+            double bestRayT = 0;
+
+            // Helper to check distance against an edge
+            Action<Segment3d> checkEdge = (seg) => {
+                double rayT, segT;
+                double distSqr = DistRay3Segment3.SquaredDistance(ref ray, ref seg, out rayT, out segT);
+                if (distSqr < minSqDist) {
+                    minSqDist = distSqr;
+                    bestRayPt = ray.Origin + rayT * ray.Direction;
+                    bestTriPt = seg.Center + segT * seg.Direction;
+                    bestRayT = rayT;
+                }
+            };
+
+            checkEdge(seg0);
+            checkEdge(seg1);
+            checkEdge(seg2);
+
+            // 3. The boundary of the Ray is its Origin (t=0).
+            // We only need to check this if the Origin projects INSIDE the triangle, 
+            // as any projection outside the triangle is already handled by the Edge checks above.
+            if (normalSqLen > MathUtil.ZeroTolerance * MathUtil.ZeroTolerance)
+            {
+                double tPlane = normal.Dot(triangle.V0 - ray.Origin) / normalSqLen;
+                Vector3d projPt = ray.Origin + tPlane * normal;
+                
+                double ptDistSqr = (ray.Origin - projPt).LengthSquared;
+                if (ptDistSqr < minSqDist) 
+                {
+                    Vector3d bary = ComputeBarycentric(projPt, triangle.V0, edge0, edge1);
+                    if (bary.x >= -MathUtil.ZeroTolerance && 
+                        bary.y >= -MathUtil.ZeroTolerance && 
+                        bary.z >= -MathUtil.ZeroTolerance)
+                    {
+                        minSqDist = ptDistSqr;
+                        bestRayPt = ray.Origin;
+                        bestTriPt = projPt;
+                        bestRayT = 0;
+                    }
+                }
+            }
+
+            // Account for numerical round-off errors.
+            if (minSqDist < 0) {
+                minSqDist = 0;
+            }
+
+            DistanceSquared = minSqDist;
+            RayClosest = bestRayPt;
+            TriangleClosest = bestTriPt;
+            RayParameter = bestRayT;
+            TriangleBaryCoords = ComputeBarycentric(bestTriPt, triangle.V0, edge0, edge1);
+
+            return DistanceSquared;
+        }
+
+        // Helper method to compute barycentric coordinates (u, v, w) of a point on the triangle plane
+        private Vector3d ComputeBarycentric(Vector3d pt, Vector3d v0, Vector3d e0, Vector3d e1)
+        {
+            Vector3d v2 = pt - v0;
+            double d00 = e0.Dot(e0);
+            double d01 = e0.Dot(e1);
+            double d11 = e1.Dot(e1);
+            double d20 = v2.Dot(e0);
+            double d21 = v2.Dot(e1);
+            double denom = d00 * d11 - d01 * d01;
+            
+            if (Math.Abs(denom) < MathUtil.ZeroTolerance) {
+                return new Vector3d(1, 0, 0); // Degenerate fallback
+            }
+            
+            double v = (d11 * d20 - d01 * d21) / denom;
+            double w = (d00 * d21 - d01 * d20) / denom;
+            double u = 1.0 - v - w;
+            
+            return new Vector3d(u, v, w);
+        }
+    }
+}

--- a/geometry4SharpTests/mesh/NTMesh3Tests.cs
+++ b/geometry4SharpTests/mesh/NTMesh3Tests.cs
@@ -63,6 +63,39 @@ namespace geometry4SharpTests.mesh
             return mesh;
         }
 
+        private static NTMesh3 CreateCube()
+        {
+            var mesh = new NTMesh3();
+
+            var v0 = mesh.AppendVertex(new Vector3d(-1.0, 1.0, -1.0));
+            var v1 = mesh.AppendVertex(new Vector3d(-1.0, 1.0, 1.0));
+            var v2 = mesh.AppendVertex(new Vector3d(1.0, 1.0, -1.0));
+            var v3 = mesh.AppendVertex(new Vector3d(1.0, 1.0, 1.0));
+
+            var v4 = mesh.AppendVertex(new Vector3d(-1.0, -1.0, -1.0));
+            var v5 = mesh.AppendVertex(new Vector3d(-1.0, -1.0, 1.0));
+            var v6 = mesh.AppendVertex(new Vector3d(1.0, -1.0, -1.0));
+            var v7 = mesh.AppendVertex(new Vector3d(1.0, -1.0, 1.0));
+
+            mesh.AppendTriangle(v3, v2, v0);
+            mesh.AppendTriangle(v0, v1, v3);
+            mesh.AppendTriangle(v4, v6, v7);
+            mesh.AppendTriangle(v7, v5, v4);
+
+            mesh.AppendTriangle(v6, v2, v3);
+            mesh.AppendTriangle(v3, v7, v6);
+            mesh.AppendTriangle(v1, v0, v4);
+            mesh.AppendTriangle(v4, v5, v1);
+
+            mesh.AppendTriangle(v5, v7, v3);
+            mesh.AppendTriangle(v3, v1, v5);
+            mesh.AppendTriangle(v2, v6, v4);
+            mesh.AppendTriangle(v4, v0, v2);
+
+            return mesh;
+        }
+
+
         #endregion
 
         [Fact]
@@ -236,6 +269,31 @@ namespace geometry4SharpTests.mesh
             trianglesE7.Contains(4);
 
             mesh.CheckValidity(FailMode.ReturnOnly).ShouldBe(true);
+        }
+
+        [Fact]
+        public void NTMesh3_ComputeNormals_NormalsShouldHaveExpectedValue()
+        {
+            var mesh = CreateCube();
+            mesh.ComputeNormals();
+
+            var n0 = new Vector3f(-0.40824828, 0.81649655, -0.40824828);
+            var n1 = new Vector3f(-0.81649655, 0.40824828, 0.40824828);
+            var n2 = new Vector3f(0.40824828, 0.40824828, -0.81649655);
+            var n3 = new Vector3f(0.57735026, 0.57735026, 0.57735026);
+            var n4 = new Vector3f(-0.57735026, -0.57735026, -0.57735026);
+            var n5 = new Vector3f(-0.40824828, -0.40824828, 0.81649655);
+            var n6 = new Vector3f(0.81649655, -0.40824828, -0.40824828);
+            var n7 = new Vector3f(0.40824828, -0.81649655, 0.40824828);
+
+            mesh.GetVertexNormal(0).Distance(n0).ShouldBe(0.0f, 1e-6f);
+            mesh.GetVertexNormal(1).Distance(n1).ShouldBe(0.0f, 1e-6f);
+            mesh.GetVertexNormal(2).Distance(n2).ShouldBe(0.0f, 1e-6f);
+            mesh.GetVertexNormal(3).Distance(n3).ShouldBe(0.0f, 1e-6f);
+            mesh.GetVertexNormal(4).Distance(n4).ShouldBe(0.0f, 1e-6f);
+            mesh.GetVertexNormal(5).Distance(n5).ShouldBe(0.0f, 1e-6f);
+            mesh.GetVertexNormal(6).Distance(n6).ShouldBe(0.0f, 1e-6f);
+            mesh.GetVertexNormal(7).Distance(n7).ShouldBe(0.0f, 1e-6f);
         }
     }
 }

--- a/geometry4SharpTests/spatial/NTMeshAABBTreeTests.cs
+++ b/geometry4SharpTests/spatial/NTMeshAABBTreeTests.cs
@@ -1,0 +1,275 @@
+using g4;
+using Shouldly;
+
+namespace geometry4SharpTests.spatial
+{
+    public class NTMeshAABBTreeTests
+    {
+        #region Test Data
+
+        private static NTMesh3 TestData()
+        {
+            var mesh = new NTMesh3();
+
+            var a1 = mesh.AppendVertex(new Vector3d(0.0, 1.0, 2.0));
+            var b1 = mesh.AppendVertex(new Vector3d(-1.0, 0.0, 2.0));
+            var c1 = mesh.AppendVertex(new Vector3d(1.0, 0.0, 2.0));
+
+            var a2 = mesh.AppendVertex(new Vector3d(-3.0, 1.0, 2.0));
+            var b2 = mesh.AppendVertex(new Vector3d(-4.0, 0.0, 2.0));
+            var c2 = mesh.AppendVertex(new Vector3d(-2.0, 0.0, 2.0));
+
+            var a3 = mesh.AppendVertex(new Vector3d(-3.0, 3.0, 2.0));
+            var b3 = mesh.AppendVertex(new Vector3d(-4.0, 2.0, 2.0));
+            var c3 = mesh.AppendVertex(new Vector3d(-2.0, 2.0, 2.0));
+
+            var a4 = mesh.AppendVertex(new Vector3d(3.0, 1.0, 2.0));
+            var b4 = mesh.AppendVertex(new Vector3d(2.0, 0.0, 2.0));
+            var c4 = mesh.AppendVertex(new Vector3d(4.0, 0.0, 2.0));
+
+            var a5 = mesh.AppendVertex(new Vector3d(3.0, 3.0, 2.0));
+            var b5 = mesh.AppendVertex(new Vector3d(2.0, 2.0, 2.0));
+            var c5 = mesh.AppendVertex(new Vector3d(4.0, 2.0, 2.0));
+
+            mesh.AppendTriangle(a1, b1, c1);
+            mesh.AppendTriangle(a2, b2, c2);
+            mesh.AppendTriangle(a3, b3, c3);
+            mesh.AppendTriangle(a4, b4, c4);
+            mesh.AppendTriangle(a5, b5, c5);
+
+            return mesh;
+        }
+
+        #endregion
+
+        [Theory]
+        [InlineData(0.0, 0.5, 2.0, 0)]
+        [InlineData(-3.0, 0.5, 2.0, 1)]
+        [InlineData(-3.0, 2.5, 2.0, 2)]
+        [InlineData(3.0, 0.5, 2.0, 3)]
+        [InlineData(3.0, 2.5, 2.0, 4)]
+        [InlineData(0.0, 0.5, 0.0, 0)]
+        [InlineData(-3.0, 0.5, 0.0, 1)]
+        [InlineData(-3.0, 2.5, 0.0, 2)]
+        [InlineData(3.0, 0.5, 0.0, 3)]
+        [InlineData(3.0, 2.5, 0.0, 4)]
+        public void NTMeshAABBTree_FindNearestTriangle_ShouldReturnExpectedTriangle(double x, double y, double z, int tid)
+        {
+            var mesh = TestData();
+            var tree = new NTMeshAABBTree3(mesh, true);
+
+            var queryPoint = new Vector3d(x, y, z);
+
+            tree.FindNearestTriangle(queryPoint).ShouldBe(tid);
+            mesh.CheckValidity(FailMode.ReturnOnly).ShouldBe(true);
+        }
+
+        [Theory]
+        [InlineData(0.0, 0.5, 2.0, 0.0)]
+        [InlineData(-3.0, 0.5, 2.0, 0.0)]
+        [InlineData(-3.0, 2.5, 2.0, 0.0)]
+        [InlineData(3.0, 0.5, 2.0, 0.0)]
+        [InlineData(3.0, 2.5, 2.0, 0.0)]
+        [InlineData(0.0, 0.5, 0.0, 2.0)]
+        [InlineData(-3.0, 0.5, 0.0, 2.0)]
+        [InlineData(-3.0, 2.5, 0.0, 2.0)]
+        [InlineData(3.0, 0.5, 0.0, 2.0)]
+        [InlineData(3.0, 2.5, 0.0, 2.0)]
+        public void NTMeshAABBTree_FindNearestTriangle_DistanceShouldBeExpectedValue(double x, double y, double z, double dist)
+        {
+            var mesh = TestData();
+            var tree = new NTMeshAABBTree3(mesh, true);
+
+            var queryPoint = new Vector3d(x, y, z);
+
+            tree.FindNearestTriangle(queryPoint, out var nearestDistSqr);
+            nearestDistSqr.ShouldBe(dist * dist, 1e-6);
+
+            mesh.CheckValidity(FailMode.ReturnOnly).ShouldBe(true);
+        }
+
+        [Theory]
+        [InlineData(0.0, 0.5, 2.0, 0.000001, 0)]
+        [InlineData(-3.0, 0.5, 2.0, 0.000001, 1)]
+        [InlineData(-3.0, 2.5, 2.0, 0.000001, 2)]
+        [InlineData(3.0, 0.5, 2.0, 0.000001, 3)]
+        [InlineData(3.0, 2.5, 2.0, 0.000001, 4)]
+        [InlineData(0.0, 0.5, 0.0, 0.000001, NTMesh3.InvalidID)]
+        [InlineData(-3.0, 0.5, 0.0, 0.000001, NTMesh3.InvalidID)]
+        [InlineData(-3.0, 2.5, 0.0, 0.000001, NTMesh3.InvalidID)]
+        [InlineData(3.0, 0.5, 0.0, 0.000001, NTMesh3.InvalidID)]
+        [InlineData(3.0, 2.5, 0.0, 0.000001, NTMesh3.InvalidID)]
+        [InlineData(0.0, 0.5, 0.0, 2.000001, 0)]
+        [InlineData(-3.0, 0.5, 0.0, 2.000001, 1)]
+        [InlineData(-3.0, 2.5, 0.0, 2.000001, 2)]
+        [InlineData(3.0, 0.5, 0.0, 2.000001, 3)]
+        [InlineData(3.0, 2.5, 0.0, 2.000001, 4)]
+        public void NTMeshAABBTree_FindNearestTriangleWithinMaximumDistance_ShouldReturnExpectedTriangle(double x, double y, double z, double maxDist, int tid)
+        {
+            var mesh = TestData();
+            var tree = new NTMeshAABBTree3(mesh, true);
+
+            var queryPoint = new Vector3d(x, y, z);
+
+            tree.FindNearestTriangle(queryPoint, maxDist).ShouldBe(tid);
+            mesh.CheckValidity(FailMode.ReturnOnly).ShouldBe(true);
+        }
+
+        [Theory]
+        [InlineData(0.0, 1.0, 0.0, NTMesh3.InvalidID)]
+        [InlineData(0.0, 0.5, 2.0, 0)]
+        [InlineData(-3.0, 0.5, 2.0, 1)]
+        [InlineData(-3.0, 2.5, 2.0, 2)]
+        [InlineData(3.0, 0.5, 2.0, 3)]
+        [InlineData(3.0, 2.5, 2.0, 4)]
+        public void NTMeshAABBTree_FindNearestHitTriangle_ShouldReturnExpectedTriangle(double tx, double ty, double tz, int tid)
+        {
+            var mesh = TestData();
+            var tree = new NTMeshAABBTree3(mesh, true);
+
+            var origin = Vector3f.Zero;
+            var target = new Vector3f(tx, ty, tz);
+            var ray = new Ray3d(origin, target - origin);
+
+            tree.FindNearestHitTriangle(ray).ShouldBe(tid);
+            mesh.CheckValidity(FailMode.ReturnOnly).ShouldBe(true);
+        }
+
+        [Theory]
+        [InlineData(0.0, 0.5, 2.0, 1e-6, 0)]
+        [InlineData(-3.0, 0.5, 2.0, 1e-6, 1)]
+        [InlineData(-3.0, 2.5, 2.0, 1e-6, 2)]
+        [InlineData(3.0, 0.5, 2.0, 1e-6, 3)]
+        [InlineData(3.0, 2.5, 2.0, 1e-6, 4)]
+        [InlineData(0.0, 0.5, 0.0, -1e-6, NTMesh3.InvalidID)]
+        [InlineData(-3.0, 0.5, 0.0, -1e-6, NTMesh3.InvalidID)]
+        [InlineData(-3.0, 2.5, 0.0, -1e-6, NTMesh3.InvalidID)]
+        [InlineData(3.0, 0.5, 0.0, -1e-6, NTMesh3.InvalidID)]
+        [InlineData(3.0, 2.5, 0.0, -1e-6, NTMesh3.InvalidID)]
+        public void NTMeshAABBTree_FindNearestHitTriangleWithinMaximumDistance_ShouldReturnExpectedTriangle(double tx, double ty, double tz, double maxDist, int tid)
+        {
+            var mesh = TestData();
+            var tree = new NTMeshAABBTree3(mesh, true);
+
+            var origin = Vector3f.Zero;
+            var target = new Vector3f(tx * 2, ty * 2, tz * 2);
+            var ray = new Ray3d(Vector3f.Zero, target - origin);
+
+            tree.FindNearestHitTriangle(ray, target.Length + maxDist).ShouldBe(tid);
+            mesh.CheckValidity(FailMode.ReturnOnly).ShouldBe(true);
+        }
+
+
+        [Fact]
+        public void NTMeshAABBTree_FindNearestHitTriangle_NotHandleCoplanarRays_ShouldReturnInvalidTriangle()
+        {
+            var mesh = TestData();
+            var tree = new NTMeshAABBTree3(mesh, true);
+
+            var origin = new Vector3f(-5.0, 0.0, 2.0);
+            var target = new Vector3f(0.0, 0.0, 2.0);
+            var ray = new Ray3d(origin, target - origin);
+
+            tree.FindNearestHitTriangle(ray).ShouldBe(NTMesh3.InvalidID);
+            mesh.CheckValidity(FailMode.ReturnOnly).ShouldBe(true);
+        }
+
+        [Fact]
+        public void NTMeshAABBTree_FindNearestHitTriangle_HandleCoplanarRays_ShouldReturnInvalidTriangle()
+        {
+            var mesh = TestData();
+            var tree = new NTMeshAABBTree3(mesh, true);
+
+            var origin = new Vector3f(-5.0, 0.0, 2.0);
+            var target = new Vector3f(0.0, 0.0, 2.0);
+            var ray = new Ray3d(origin, target - origin);
+
+            tree.FindNearestHitTriangle(ray, handleCoplanarRays: true).ShouldBe(1);
+            mesh.CheckValidity(FailMode.ReturnOnly).ShouldBe(true);
+        }
+
+        [Fact]
+        public void NTMeshAABBTree_FindAllHitTriangles_NotHandleCoplanarRays_ShouldReturnInvalidTriangle()
+        {
+            var mesh = TestData();
+            var tree = new NTMeshAABBTree3(mesh, true);
+
+            var origin = new Vector3f(-5.0, 0.0, 2.0);
+            var target = new Vector3f(0.0, 0.0, 2.0);
+            var ray = new Ray3d(origin, target - origin);
+
+            var hitTriangles = new List<int>();
+            tree.FindAllHitTriangles(ray, hitTriangles).ShouldBe(0);
+            hitTriangles.Count().ShouldBe(0);
+
+            mesh.CheckValidity(FailMode.ReturnOnly).ShouldBe(true);
+        }
+
+        [Fact]
+        public void NTMeshAABBTree_FindAllHitTrianglesWithinMaximumDistance_HandleCoplanarRays_ShouldReturnInvalidTriangle()
+        {
+            var mesh = TestData();
+            var tree = new NTMeshAABBTree3(mesh, true);
+
+            var origin = new Vector3f(-5.0, 0.0, 2.0);
+            var target = new Vector3f(0.0, 0.0, 2.0);
+            var ray = new Ray3d(origin, target - origin);
+
+            var maxDist = 1.000001;
+            var hitTriangles = new List<int>();
+            tree.FindAllHitTriangles(ray, hitTriangles, maxDist, handleCoplanarRays: true).ShouldBe(1);
+            hitTriangles.Count.ShouldBe(1);
+            hitTriangles.Contains(1).ShouldBe(true);
+
+            mesh.CheckValidity(FailMode.ReturnOnly).ShouldBe(true);
+        }
+
+        [Theory]
+        [InlineData(0.0, 1.5, 0.0, 0.5, 0)]
+        [InlineData(-3.0, 1.5, 0.0, 0.5, 1)]
+        [InlineData(-3.0, 3.5, 0.0, 0.5, 2)]
+        [InlineData(3.0, 1.5, 0.0, 0.5, 3)]
+        [InlineData(3.0, 3.5, 0.0, 0.5, 4)]
+        [InlineData(0.0, 1.5, 0.0, 0.499999, NTMesh3.InvalidID)]
+        [InlineData(-3.0, 1.5, 0.0, 0.499999, NTMesh3.InvalidID)]
+        [InlineData(-3.0, 3.5, 0.0, 0.499999, NTMesh3.InvalidID)]
+        [InlineData(3.0, 1.5, 0.0, 0.499999, NTMesh3.InvalidID)]
+        [InlineData(3.0, 3.5, 0.0, 0.499999, NTMesh3.InvalidID)]
+        public void NTMeshAABBTree_FindNearestBeamHitTriangle_ShouldReturnExpectedTriangle(double ox, double oy, double oz, double radius, int tid)
+        {
+            var mesh = TestData();
+            var tree = new NTMeshAABBTree3(mesh, true);
+
+            var origin = new Vector3d(ox, oy, oz);
+            var direction = Vector3d.AxisZ;
+            var ray = new Ray3d(origin, direction);
+
+            tree.FindNearestBeamHitTriangle(ray, radius).ShouldBe(tid);
+            mesh.CheckValidity(FailMode.ReturnOnly).ShouldBe(true);
+        }
+
+        [Theory]
+        [InlineData(0.0, 1.5, 0.0, 0.5, 2.000001, 0)]
+        [InlineData(-3.0, 1.5, 0.0, 0.5, 2.000001, 1)]
+        [InlineData(-3.0, 3.5, 0.0, 0.5, 2.000001, 2)]
+        [InlineData(3.0, 1.5, 0.0, 0.5, 2.000001, 3)]
+        [InlineData(3.0, 3.5, 0.0, 0.5, 2.000001, 4)]
+        [InlineData(0.0, 1.5, 0.0, 0.5, 2.0, NTMesh3.InvalidID)]
+        [InlineData(-3.0, 1.5, 0.0, 0.5, 2.0, NTMesh3.InvalidID)]
+        [InlineData(-3.0, 3.5, 0.0, 0.5, 2.0, NTMesh3.InvalidID)]
+        [InlineData(3.0, 1.5, 0.0, 0.5, 2.0, NTMesh3.InvalidID)]
+        [InlineData(3.0, 3.5, 0.0, 0.5, 2.0, NTMesh3.InvalidID)]
+        public void NTMeshAABBTree_FindNearestBeamHitTriangleWithinMaximumDistance_ShouldReturnExpectedTriangle(double ox, double oy, double oz, double radius, double maxDistance, int tid)
+        {
+            var mesh = TestData();
+            var tree = new NTMeshAABBTree3(mesh, true);
+
+            var origin = new Vector3d(ox, oy, oz);
+            var direction = Vector3d.AxisZ;
+            var ray = new Ray3d(origin, direction);
+
+            tree.FindNearestBeamHitTriangle(ray, radius, maxDistance).ShouldBe(tid);
+            mesh.CheckValidity(FailMode.ReturnOnly).ShouldBe(true);
+        }
+    }
+}

--- a/geometry4Sharp_netstandard.csproj
+++ b/geometry4Sharp_netstandard.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.4.0</Version>
+    <Version>1.1.5.0</Version>
     <Title>geometry4Sharp</Title>
     <Authors></Authors>
     <Company></Company>

--- a/intersection/IntrRay3Triangle3.cs
+++ b/intersection/IntrRay3Triangle3.cs
@@ -108,12 +108,92 @@ namespace g4
             return false;
         }
 
+        // 3. Origin is outside. Check intersection with all 3 edges.
+        private static bool CheckEdge(ref Ray3d ray, ref Vector3d start, ref Vector3d E, ref double minT, ref Vector3d normal)
+        {
+            Vector3d N_edge = E.Cross(ref normal);
+            double det = ray.Direction.Dot(ref N_edge);
 
+            var hit = false;
+            if (Math.Abs(det) > MathUtil.ZeroTolerance)
+            {
+                Vector3d startToOrigin = start - ray.Origin;
+                double t = startToOrigin.Dot(ref N_edge) / det;
+
+                if (t >= 0 && t < minT)
+                {
+                    Vector3d P = ray.Origin + (ray.Direction * t);
+                    Vector3d P_minus_start = P - start;
+                    double u = P_minus_start.Dot(ref E) / E.Dot(ref E);
+
+                    if (u >= -MathUtil.ZeroTolerance && u <= 1.0 + MathUtil.ZeroTolerance)
+                    {
+                        minT = t;
+                        hit = true;
+                    }
+                }
+            }
+
+            return hit;
+        }
+
+
+        private static bool HandleCoplanarEdgeCase(ref Ray3d ray, ref Vector3d V0, ref Vector3d V1, ref Vector3d V2, out double rayT)
+        {
+            rayT = double.MaxValue;
+
+            // Recalculate the initial triangle data (cheap and keeps the signature clean)
+            Vector3d edge1 = V1 - V0;
+            Vector3d edge2 = V2 - V0;
+            Vector3d normal = edge1.Cross(ref edge2);
+            Vector3d diff = ray.Origin - V0;
+
+            // 1. Verify Coplanarity
+            double distFromPlane = diff.Dot(ref normal);
+            if (Math.Abs(distFromPlane) > MathUtil.ZeroTolerance)
+            {
+                return false; // Parallel, but hovering above/below the triangle
+            }
+
+            bool hit = false;
+            double minT = double.MaxValue;
+
+            // Calculate remaining edges and diffs
+            Vector3d edge3 = V2 - V1;
+            Vector3d edge4 = V0 - V2;
+            Vector3d diff1 = ray.Origin - V1;
+            Vector3d diff2 = ray.Origin - V2;
+
+            // 2. Is the ray origin inside the triangle?
+            Vector3d cross0 = edge1.Cross(ref diff);
+            Vector3d cross1 = edge3.Cross(ref diff1);
+            Vector3d cross2 = edge4.Cross(ref diff2);
+
+            if (cross0.Dot(ref normal) >= -MathUtil.ZeroTolerance &&
+                cross1.Dot(ref normal) >= -MathUtil.ZeroTolerance &&
+                cross2.Dot(ref normal) >= -MathUtil.ZeroTolerance)
+            {
+                rayT = 0.0;
+                return true;
+            }
+
+            hit |= CheckEdge(ref ray, ref V0, ref edge1, ref minT, ref normal);
+            hit |= CheckEdge(ref ray, ref V1, ref edge3, ref minT, ref normal);
+            hit |= CheckEdge(ref ray, ref V2, ref edge4, ref minT, ref normal);
+
+            if (hit)
+            {
+                rayT = minT;
+                return true;
+            }
+
+            return false;
+        }
 
         /// <summary>
         /// minimal intersection test, computes ray-t
         /// </summary>
-        public static bool Intersects(ref Ray3d ray, ref Vector3d V0, ref Vector3d V1, ref Vector3d V2, out double rayT)
+        public static bool Intersects(ref Ray3d ray, ref Vector3d V0, ref Vector3d V1, ref Vector3d V2, out double rayT, bool handleCoplanarRays = false)
         {
             // Compute the offset origin, edges, and normal.
             Vector3d diff = ray.Origin - V0;
@@ -136,9 +216,8 @@ namespace g4
                 sign = -1;
                 DdN = -DdN;
             } else {
-                // Ray and triangle are parallel, call it a "no intersection"
-                // even if the ray does intersect.
-                return false;
+                return handleCoplanarRays ? 
+                    HandleCoplanarEdgeCase(ref ray, ref V0, ref V1, ref V2, out rayT) : false;
             }
 
             Vector3d cross = diff.Cross(ref edge2);

--- a/mesh/NTMesh3.cs
+++ b/mesh/NTMesh3.cs
@@ -46,6 +46,7 @@ namespace g4
 
         int timestamp = 0;
 		int shape_timestamp = 0;
+		int normal_timestamp = -1;
 
 		int max_group_id = 0;
 		int max_vertex_group_id = 0;
@@ -325,11 +326,12 @@ namespace g4
 
 		public int Timestamp { get { return timestamp; } }
 		public int ShapeTimestamp { get { return shape_timestamp; } }
+        public int NormalTimestamp { get { return normal_timestamp; } }
 
 
-		// IMesh impl
+        // IMesh impl
 
-		public int VertexCount { get { return vertices_refcount.count; } }
+        public int VertexCount { get { return vertices_refcount.count; } }
 		public int TriangleCount { get { return triangles_refcount.count; } }
 		public int EdgeCount { get { return edges_refcount.count; } }
 
@@ -358,6 +360,11 @@ namespace g4
 
 		public void ComputeNormals(bool bApplyAreaWeighting)
 		{
+			if (normal_timestamp == timestamp)
+			{
+				return;
+			}
+
 			if (bApplyAreaWeighting)
 			{
 				ComputeNormalsAreaWeighted();
@@ -366,6 +373,8 @@ namespace g4
 			{
 				ComputeNormalsSimpleAverage();
 			}
+
+			normal_timestamp = timestamp;
 		}
 
 		// Calculates the normal of each vertex as the average of the normals

--- a/mesh/NTMesh3.cs
+++ b/mesh/NTMesh3.cs
@@ -26,11 +26,11 @@ namespace g4
 		public static readonly Index3i InvalidTriangle = new Index3i(InvalidID, InvalidID, InvalidID);
 		public static readonly Index2i InvalidEdge = new Index2i(InvalidID, InvalidID);
 
-		DVector<double> vertices;
-		DVector<float> normals;
-		DVector<float> colors;
+		protected DVector<double> vertices;
+		protected DVector<float> normals;
+		protected DVector<float> colors;
 
-		DVector<int> triangles;
+		protected DVector<int> triangles;
         DVector<int> edges;
         DVector<int> triangle_groups;
         DVector<int> vertex_groups;
@@ -118,11 +118,11 @@ namespace g4
 
 
 		public NTMesh3(NTMesh3 copy) {
-			Copy(copy, true, true);
+			Copy(copy, copy.HasVertexNormals, copy.HasVertexColors);
 		}
 
 
-		public void Copy(NTMesh3 copy, bool bNormals = true, bool bColors = true)
+		public void Copy(NTMesh3 copy, bool bNormals, bool bColors)
 		{
 			vertices = new DVector<double>(copy.vertices);
 			normals = (bNormals && copy.normals != null) ? new DVector<float>(copy.normals) : null;
@@ -153,8 +153,157 @@ namespace g4
 			updateTimeStamp(true);
 		}
 
+		protected void CopyByReference(NTMesh3 copy)
+		{
+            vertices = copy.vertices;
+			normals = copy.normals;
+			colors = copy.colors;
 
-		public NTMesh3(DMesh3 copy)
+			triangles = copy.triangles;
+			edges = copy.edges;
+			triangle_groups = copy.triangle_groups;
+			vertex_groups = copy.vertex_groups;
+
+
+			vertex_edges = copy.vertex_edges;
+			edge_triangles = copy.edge_triangles;
+			triangle_edges = copy.triangle_edges;
+
+			vertices_refcount = copy.vertices_refcount;
+			triangles_refcount = copy.triangles_refcount;
+			edges_refcount = copy.edges_refcount;
+
+			timestamp = copy.timestamp;
+			shape_timestamp = copy.shape_timestamp;
+
+			max_group_id = copy.max_group_id;
+			max_vertex_group_id = copy.max_vertex_group_id;
+
+			cached_bounds = copy.cached_bounds;
+			cached_bounds_timestamp = copy.cached_bounds_timestamp;
+
+			cached_is_closed = copy.cached_is_closed;
+			cached_is_closed_timstamp = copy.cached_is_closed_timstamp;
+
+			cached_has_non_manifold_edge = copy.cached_has_non_manifold_edge;
+			cached_has_non_manifold_edge_timestamp = copy.cached_has_non_manifold_edge_timestamp;
+
+			cached_has_self_intersections = copy.cached_has_self_intersections;
+			cached_has_self_intersections_timestamp = copy.cached_has_self_intersections_timestamp;
+
+			cached_number_of_components = copy.cached_number_of_components;
+			cached_number_of_components_timestamp = copy.cached_number_of_components_timestamp;
+		}
+
+		// This method assumes that vertices, normals, colors, and triangles are correct,
+		// and rebuilds all other indexing structures.
+        protected void RebuildIndexingStructures(bool bWantTriGroups = false, bool bWantVtxGroups = false)
+        {
+            // Completely reset all structural and refcount objects
+            edges = new DVector<int>();
+            edges_refcount = new RefCountVector();
+            vertex_edges = new SmallListSet();
+            edge_triangles = new SmallListSet();
+
+            triangle_edges = new DVector<int>();
+            triangle_edges.resize(triangles.Length);
+
+            vertices_refcount = new RefCountVector();
+            triangles_refcount = new RefCountVector();
+
+            // Handle Triangle Groups
+            if (bWantTriGroups)
+            {
+                triangle_groups = new DVector<int>();
+                triangle_groups.resize(triangles.Length / 3);
+                for (int i = 0; i < triangle_groups.size; ++i)
+                {
+                    triangle_groups[i] = -1;
+                }
+                max_group_id = 0;
+            }
+            else
+            {
+                triangle_groups = null;
+                max_group_id = 0;
+            }
+
+            // Handle Vertex Groups
+            if (bWantVtxGroups)
+            {
+                vertex_groups = new DVector<int>();
+                vertex_groups.resize(vertices.Length / 3);
+                for (int i = 0; i < vertex_groups.size; ++i)
+                {
+                    vertex_groups[i] = -1;
+                }
+                max_vertex_group_id = 0;
+            }
+            else
+            {
+                vertex_groups = null;
+                max_vertex_group_id = 0;
+            }
+
+            // Rebuild Vertex RefCounts
+            // A RefCountVector's allocate() method sequentially returns 0, 1, 2... 
+            // and sets the base refCount to 1 (representing an isolated vertex).
+            int max_vid = vertices.Length / 3;
+            for (int vid = 0; vid < max_vid; vid++)
+            {
+                int allocated_vid = vertices_refcount.allocate();
+                Debug.Assert(allocated_vid == vid, "Vertex allocation out of sync");
+
+                // Prepare the edge lists for this newly registered vertex
+                allocate_vertex_edges_list(vid);
+            }
+
+            // Rebuild Triangle RefCounts, Edges, and Vertex Adjacencies
+            int max_tid = triangles.Length / 3;
+            for (int tid = 0; tid < max_tid; tid++)
+            {
+                int i = 3 * tid;
+                int v0 = triangles[i];
+                int v1 = triangles[i + 1];
+                int v2 = triangles[i + 2];
+
+                // Safely handle potential gaps or degenerate triangles in your custom arrays
+                if (v0 == InvalidID || v0 == v1 || v1 == v2 || v2 == v0)
+                {
+                    // Allocate to keep the ID counter in sync, but immediately free it
+                    int skipped_tid = triangles_refcount.allocate();
+                    triangles_refcount.decrement(skipped_tid);
+                    continue;
+                }
+
+                // Register the triangle (sets its refCount to 1)
+                int allocated_tid = triangles_refcount.allocate();
+                Debug.Assert(allocated_tid == tid, "Triangle allocation out of sync");
+
+                // Increment the vertex refcounts for this valid triangle
+                // (A vertex with 2 connected triangles will end up with a refCount of 3)
+                vertices_refcount.increment(v0);
+                vertices_refcount.increment(v1);
+                vertices_refcount.increment(v2);
+
+                // Find existing edges
+                int e0 = find_edge(v0, v1);
+                int e1 = find_edge(v1, v2);
+                int e2 = find_edge(v2, v0);
+
+                // Register the edges, and associates triangles and edges
+				// If the edge doesn't exist, add_tri_edge() creates a new one
+                add_tri_edge(tid, v0, v1, 0, e0);
+                add_tri_edge(tid, v1, v2, 1, e1);
+                add_tri_edge(tid, v2, v0, 2, e2);
+            }
+
+            // Update internal tracking state to invalidate cached bounds/closed-checks
+            updateTimeStamp(true);
+        }
+
+
+        public NTMesh3(DMesh3 copy)
 		{
 			allocate(copy.HasVertexNormals, copy.HasVertexColors, copy.HasTriangleGroups, false);
 
@@ -204,6 +353,158 @@ namespace g4
 				if (colors != null) c |= MeshComponents.VertexColors;
 				if (triangle_groups != null) c |= MeshComponents.FaceGroups;
 				return c;
+			}
+		}
+
+		public void ComputeNormals(bool bApplyAreaWeighting)
+		{
+			if (bApplyAreaWeighting)
+			{
+				ComputeNormalsAreaWeighted();
+			}
+			else
+			{
+				ComputeNormalsSimpleAverage();
+			}
+		}
+
+		// Calculates the normal of each vertex as the average of the normals
+		// of its triangles, weighted by their area.
+        private void ComputeNormalsAreaWeighted()
+        {
+			if (normals == null)
+			{
+				normals = new DVector<float>();
+			}
+
+			if (normals.Length != vertices.Length)
+			{
+				normals.resize(vertices.Length);
+			}
+
+			// Resetting the normals
+			for (int i = 0; i < normals.size; i++)
+			{
+				normals[i] = 0.0f;
+			}
+
+            // Scatter Pass: Accumulate Raw Cross Products
+            foreach (int tid in TriangleIndices())
+            {
+                Index3i t = GetTriangle(tid);
+                Vector3d v0 = GetVertex(t.a);
+                Vector3d v1 = GetVertex(t.b);
+                Vector3d v2 = GetVertex(t.c);
+
+                // Calculating the raw cross product: (v1-v0) x (v2-v0)
+                // The cross product magnitude is 2x triangle area; adding this 
+                // "un-normalized" vector automatically weights by area.
+                double dx1 = v1.x - v0.x, dy1 = v1.y - v0.y, dz1 = v1.z - v0.z;
+                double dx2 = v2.x - v0.x, dy2 = v2.y - v0.y, dz2 = v2.z - v0.z;
+
+                float nx = (float)(dy1 * dz2 - dz1 * dy2);
+                float ny = (float)(dz1 * dx2 - dx1 * dz2);
+                float nz = (float)(dx1 * dy2 - dy1 * dx2);
+
+                // Accumulating into the triangle vertices
+                normals[3 * t.a] += nx;
+                normals[3 * t.a + 1] += ny;
+                normals[3 * t.a + 2] += nz;
+
+                normals[3 * t.b] += nx;
+                normals[3 * t.b + 1] += ny;
+                normals[3 * t.b + 2] += nz;
+
+                normals[3 * t.c] += nx;
+                normals[3 * t.c + 1] += ny;
+                normals[3 * t.c + 2] += nz;
+            }
+
+            // Normalization Pass
+            foreach (int vid in VertexIndices())
+            {
+                int n = 3 * vid;
+                float x = normals[n], y = normals[n + 1], z = normals[n + 2];
+                float lenSq = x * x + y * y + z * z;
+
+                if (lenSq > MathUtil.ZeroTolerancef)
+                {
+                    float s = 1.0f / (float)Math.Sqrt(lenSq);
+                    normals[n] *= s;
+                    normals[n + 1] *= s;
+                    normals[n + 2] *= s;
+                }
+                else
+                {
+                    // Fallback for isolated vertices
+                    normals[n] = 0; normals[n + 1] = 0; normals[n + 2] = 0;
+                }
+            }
+        }
+
+		// Implementation with simple average
+		private void ComputeNormalsSimpleAverage()
+		{
+			if (normals == null)
+			{
+				normals = new DVector<float>();
+			}
+
+			if (normals.Length != vertices.Length)
+			{
+				normals.resize(vertices.Length);
+			}
+
+			var accumulatedNormal = new Vector3f();
+			var triangle = new Triangle3d();
+			foreach (var vid in VertexIndices())
+			{
+				var index = 3 * vid;
+				var vertexTriangleCount = 0;
+				accumulatedNormal.x = 0.0f;
+				accumulatedNormal.y = 0.0f;
+				accumulatedNormal.z = 0.0f;
+				foreach (var tid in VtxTrianglesItr(vid))
+				{
+					// Calculating the normal of each triangle
+					var tvids = GetTriangle(tid);
+					triangle.V0 = GetVertex(tvids.a);
+					triangle.V1 = GetVertex(tvids.b);
+					triangle.V2 = GetVertex(tvids.c);
+
+					var normal = triangle.Normal;
+					accumulatedNormal.x += (float)normal.x;
+					accumulatedNormal.y += (float)normal.y;
+					accumulatedNormal.z += (float)normal.z;
+					vertexTriangleCount++;
+				}
+
+				// Handling isolated vertices
+				if (vertexTriangleCount == 0)
+				{
+					// Setting the normal to zero
+					normals[index] = 0.0f;
+					normals[index + 1] = 0.0f;
+					normals[index + 2] = 0.0f;
+					continue;
+				}
+
+				// Handling degenerate normal
+				if (accumulatedNormal.LengthSquared < MathUtil.ZeroTolerancef)
+				{
+					// Setting the normal to zero
+					normals[index] = 0.0f;
+					normals[index + 1] = 0.0f;
+					normals[index + 2] = 0.0f;
+					continue;
+				}
+
+				// Normalizing the average normal
+				accumulatedNormal.Normalize();
+
+				normals[index] = accumulatedNormal.x;
+				normals[index + 1] = accumulatedNormal.y;
+				normals[index + 2] = accumulatedNormal.z;
 			}
 		}
 

--- a/mesh/NTMesh3.cs
+++ b/mesh/NTMesh3.cs
@@ -358,7 +358,7 @@ namespace g4
 			}
 		}
 
-		public void ComputeNormals(bool bApplyAreaWeighting)
+		public void ComputeNormals(bool bApplyAreaWeighting = true)
 		{
 			if (normal_timestamp == timestamp)
 			{

--- a/spatial/DMeshAABBTree.cs
+++ b/spatial/DMeshAABBTree.cs
@@ -269,7 +269,7 @@ namespace g4
         /// find id of first triangle that ray hits, within distance fMaxDist, or return DMesh3.InvalidID
         /// Use MeshQueries.TriangleIntersection() to get more information
         /// </summary>
-        public virtual int FindNearestHitTriangle(Ray3d ray, double fMaxDist = double.MaxValue)
+        public virtual int FindNearestHitTriangle(Ray3d ray, double fMaxDist = double.MaxValue, bool handleCoplanarRays = false)
         {
             if (mesh_timestamp != mesh.ShapeTimestamp)
                 throw new Exception("DMeshAABBTree3.FindNearestHitTriangle: mesh has been modified since tree construction");
@@ -281,11 +281,11 @@ namespace g4
             //   nearestT to double.MaxValue, then we will test all boxes (!)
             double fNearestT = (fMaxDist < double.MaxValue) ? fMaxDist : float.MaxValue;
             int tNearID = DMesh3.InvalidID;
-            find_hit_triangle(root_index, ref ray, ref fNearestT, ref tNearID);
+            find_hit_triangle(root_index, ref ray, ref fNearestT, ref tNearID, handleCoplanarRays);
             return tNearID;
         }
 
-        protected void find_hit_triangle(int iBox, ref Ray3d ray, ref double fNearestT, ref int tID)
+        protected void find_hit_triangle(int iBox, ref Ray3d ray, ref double fNearestT, ref int tID, bool handleCoplanarRays = false)
         {
             int idx = box_to_index[iBox];
             if ( idx < triangles_end ) {            // triange-list case, array is [N t1 t2 ... tN]
@@ -298,7 +298,7 @@ namespace g4
 
                     mesh.GetTriVertices(ti, ref tri.V0, ref tri.V1, ref tri.V2);
                     double rayt;
-                    if (IntrRay3Triangle3.Intersects(ref ray, ref tri.V0, ref tri.V1, ref tri.V2, out rayt)) {
+                    if (IntrRay3Triangle3.Intersects(ref ray, ref tri.V0, ref tri.V1, ref tri.V2, out rayt, handleCoplanarRays)) {
                         if (rayt < fNearestT) {
                             fNearestT = rayt;
                             tID = ti;
@@ -321,7 +321,7 @@ namespace g4
                     iChild1 = (-iChild1) - 1;
                     double fChild1T = box_ray_intersect_t(iChild1, ray);
                     if (fChild1T <= fNearestT + e) {
-                        find_hit_triangle(iChild1, ref ray, ref fNearestT, ref tID);
+                        find_hit_triangle(iChild1, ref ray, ref fNearestT, ref tID, handleCoplanarRays);
                     }
 
                 } else {                            // 2 children, descend closest first
@@ -332,16 +332,16 @@ namespace g4
                     double fChild2T = box_ray_intersect_t(iChild2, ray);
                     if (fChild1T < fChild2T) {
                         if (fChild1T <= fNearestT + e) {
-                            find_hit_triangle(iChild1, ref ray, ref fNearestT, ref tID);
+                            find_hit_triangle(iChild1, ref ray, ref fNearestT, ref tID, handleCoplanarRays);
                             if (fChild2T <= fNearestT + e) {
-                                find_hit_triangle(iChild2, ref ray, ref fNearestT, ref tID);
+                                find_hit_triangle(iChild2, ref ray, ref fNearestT, ref tID, handleCoplanarRays);
                             }
                         }
                     } else {
                         if (fChild2T <= fNearestT + e) {
-                            find_hit_triangle(iChild2, ref ray, ref fNearestT, ref tID);
+                            find_hit_triangle(iChild2, ref ray, ref fNearestT, ref tID, handleCoplanarRays);
                             if (fChild1T <= fNearestT + e) {
-                                find_hit_triangle(iChild1, ref ray, ref fNearestT, ref tID);
+                                find_hit_triangle(iChild1, ref ray, ref fNearestT, ref tID, handleCoplanarRays);
                             }
                         }
                     }

--- a/spatial/EditMeshSpatial.cs
+++ b/spatial/EditMeshSpatial.cs
@@ -48,7 +48,8 @@ namespace g4
 
         public bool SupportsTriangleRayIntersection { get { return true; } }
 
-        public int FindNearestHitTriangle(Ray3d ray, double fMaxDist = double.MaxValue)
+        // Not handling coplanar rays here
+        public int FindNearestHitTriangle(Ray3d ray, double fMaxDist = double.MaxValue, bool handleCoplanarRays = false)
         {
             var save_filter = SourceSpatial.TriangleFilterF;
             SourceSpatial.TriangleFilterF = source_filter;

--- a/spatial/NTMeshAABBTree.cs
+++ b/spatial/NTMeshAABBTree.cs
@@ -488,7 +488,127 @@ namespace g4
             return hit_count;
         }
 
+        /// <summary>
+        /// BEAM TRACING: Find the nearest triangle that comes within 'radius' of the ray, 
+        /// within distance fMaxDist. Conceptually casts a capsule/cylinder along the ray.
+        /// </summary>
+        public virtual int FindNearestBeamHitTriangle(Ray3d ray, double radius, double fMaxDist = double.MaxValue)
+        {
+            if (mesh_timestamp != mesh.ShapeTimestamp)
+                throw new Exception("NTMeshAABBTree3.FindNearestBeamHitTriangle: mesh has been modified");
+            if (ray.Direction.IsNormalized == false)
+                throw new Exception("NTMeshAABBTree3.FindNearestBeamHitTriangle: ray direction is not normalized");
 
+            double fNearestT = (fMaxDist < double.MaxValue) ? fMaxDist : float.MaxValue;
+            int tNearID = DMesh3.InvalidID;
+
+            find_beam_hit_triangle(root_index, ref ray, radius, ref fNearestT, ref tNearID);
+
+            return tNearID;
+        }
+
+        protected void find_beam_hit_triangle(int iBox, ref Ray3d ray, double radius, ref double fNearestT, ref int tID)
+        {
+            int idx = box_to_index[iBox];
+            if (idx < triangles_end)
+            {
+                // Base Case: Test triangles inside this BVH leaf
+                Triangle3d tri = new Triangle3d();
+                int num_tris = index_list[idx];
+                for (int i = 1; i <= num_tris; ++i)
+                {
+                    int ti = index_list[idx + i];
+                    if (TriangleFilterF != null && TriangleFilterF(ti) == false)
+                        continue;
+
+                    mesh.GetTriVertices(ti, ref tri.V0, ref tri.V1, ref tri.V2);
+
+                    // Calculate the exact distance between the infinite ray and the triangle
+                    DistRay3Triangle3 distQuery = new DistRay3Triangle3(ray, tri);
+                    double distSqr = distQuery.GetSquared();
+
+                    // If the distance is smaller than the beam radius, it's a hit!
+                    if (distSqr <= radius * radius)
+                    {
+                        double rayt = distQuery.RayParameter;
+
+                        // Ignore hits that are strictly behind the ray origin
+                        if (rayt > -radius && rayt < fNearestT)
+                        {
+                            fNearestT = rayt;
+                            tID = ti;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                // Internal Node: Test expanded child boxes
+                double e = MathUtil.ZeroTolerancef;
+
+                int iChild1 = index_list[idx];
+                if (iChild1 < 0)
+                {
+                    // 1 child
+                    iChild1 = (-iChild1) - 1;
+                    double fChild1T = box_beam_intersect_t(iChild1, ray, radius);
+                    if (fChild1T <= fNearestT + e)
+                        find_beam_hit_triangle(iChild1, ref ray, radius, ref fNearestT, ref tID);
+                }
+                else
+                {
+                    // 2 children, descend into the closest box first to maximize early-outs
+                    iChild1 = iChild1 - 1;
+                    int iChild2 = index_list[idx + 1] - 1;
+
+                    double fChild1T = box_beam_intersect_t(iChild1, ray, radius);
+                    double fChild2T = box_beam_intersect_t(iChild2, ray, radius);
+
+                    if (fChild1T < fChild2T)
+                    {
+                        if (fChild1T <= fNearestT + e)
+                        {
+                            find_beam_hit_triangle(iChild1, ref ray, radius, ref fNearestT, ref tID);
+                            if (fChild2T <= fNearestT + e)
+                                find_beam_hit_triangle(iChild2, ref ray, radius, ref fNearestT, ref tID);
+                        }
+                    }
+                    else
+                    {
+                        if (fChild2T <= fNearestT + e)
+                        {
+                            find_beam_hit_triangle(iChild2, ref ray, radius, ref fNearestT, ref tID);
+                            if (fChild1T <= fNearestT + e)
+                                find_beam_hit_triangle(iChild1, ref ray, radius, ref fNearestT, ref tID);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Helper: Tests intersection against an AABB that has been expanded by the beam's radius
+        protected double box_beam_intersect_t(int iBox, Ray3d ray, double radius)
+        {
+            Vector3d c = (Vector3d)box_centers[iBox];
+            Vector3f e = box_extents[iBox];
+
+            // Expand the bounds in all directions by the beam radius.
+            // Note: This results in a slightly "blocky" conservative check (AABB expansion rather than strict sphere expansion), 
+            // but it is incredibly fast and perfectly safe for BVH culling.
+            AxisAlignedBox3d expanded_box = new AxisAlignedBox3d(
+                ref c,
+                e.x + box_eps + radius,
+                e.y + box_eps + radius,
+                e.z + box_eps + radius
+            );
+
+            double ray_t;
+            if (IntrRay3AxisAlignedBox3.FindRayIntersectT(ref ray, ref expanded_box, out ray_t))
+            {
+                return ray_t;
+            }
+            return double.MaxValue;
+        }
 
 
         /// <summary>

--- a/spatial/NTMeshAABBTree.cs
+++ b/spatial/NTMeshAABBTree.cs
@@ -296,7 +296,7 @@ namespace g4
         /// find id of first triangle that ray hits, within distance fMaxDist, or return DMesh3.InvalidID
         /// Use MeshQueries.TriangleIntersection() to get more information
         /// </summary>
-        public virtual int FindNearestHitTriangle(Ray3d ray, double fMaxDist = double.MaxValue)
+        public virtual int FindNearestHitTriangle(Ray3d ray, double fMaxDist = double.MaxValue, bool handleCoplanarRays = false)
         {
             if (mesh_timestamp != mesh.ShapeTimestamp)
                 throw new Exception("NTMeshAABBTree3.FindNearestHitTriangle: mesh has been modified since tree construction");
@@ -308,11 +308,11 @@ namespace g4
             //   nearestT to double.MaxValue, then we will test all boxes (!)
             double fNearestT = (fMaxDist < double.MaxValue) ? fMaxDist : float.MaxValue;
             int tNearID = DMesh3.InvalidID;
-            find_hit_triangle(root_index, ref ray, ref fNearestT, ref tNearID);
+            find_hit_triangle(root_index, ref ray, ref fNearestT, ref tNearID, handleCoplanarRays);
             return tNearID;
         }
 
-        protected void find_hit_triangle(int iBox, ref Ray3d ray, ref double fNearestT, ref int tID)
+        protected void find_hit_triangle(int iBox, ref Ray3d ray, ref double fNearestT, ref int tID, bool handleCoplanarRays = false)
         {
             int idx = box_to_index[iBox];
             if (idx < triangles_end)
@@ -327,7 +327,7 @@ namespace g4
 
                     mesh.GetTriVertices(ti, ref tri.V0, ref tri.V1, ref tri.V2);
                     double rayt;
-                    if (IntrRay3Triangle3.Intersects(ref ray, ref tri.V0, ref tri.V1, ref tri.V2, out rayt))
+                    if (IntrRay3Triangle3.Intersects(ref ray, ref tri.V0, ref tri.V1, ref tri.V2, out rayt, handleCoplanarRays))
                     {
                         if (rayt < fNearestT)
                         {
@@ -356,7 +356,7 @@ namespace g4
                     double fChild1T = box_ray_intersect_t(iChild1, ray);
                     if (fChild1T <= fNearestT + e)
                     {
-                        find_hit_triangle(iChild1, ref ray, ref fNearestT, ref tID);
+                        find_hit_triangle(iChild1, ref ray, ref fNearestT, ref tID, handleCoplanarRays);
                     }
 
                 }
@@ -371,10 +371,10 @@ namespace g4
                     {
                         if (fChild1T <= fNearestT + e)
                         {
-                            find_hit_triangle(iChild1, ref ray, ref fNearestT, ref tID);
+                            find_hit_triangle(iChild1, ref ray, ref fNearestT, ref tID, handleCoplanarRays);
                             if (fChild2T <= fNearestT + e)
                             {
-                                find_hit_triangle(iChild2, ref ray, ref fNearestT, ref tID);
+                                find_hit_triangle(iChild2, ref ray, ref fNearestT, ref tID, handleCoplanarRays);
                             }
                         }
                     }
@@ -382,10 +382,10 @@ namespace g4
                     {
                         if (fChild2T <= fNearestT + e)
                         {
-                            find_hit_triangle(iChild2, ref ray, ref fNearestT, ref tID);
+                            find_hit_triangle(iChild2, ref ray, ref fNearestT, ref tID, handleCoplanarRays);
                             if (fChild1T <= fNearestT + e)
                             {
-                                find_hit_triangle(iChild1, ref ray, ref fNearestT, ref tID);
+                                find_hit_triangle(iChild1, ref ray, ref fNearestT, ref tID, handleCoplanarRays);
                             }
                         }
                     }
@@ -405,7 +405,7 @@ namespace g4
         /// Find the ids of all the triangles that they ray intersects, within distance fMaxDist from ray origin
         /// Returns count of triangles.
         /// </summary>
-        public virtual int FindAllHitTriangles(Ray3d ray, List<int> hitTriangles = null, double fMaxDist = double.MaxValue)
+        public virtual int FindAllHitTriangles(Ray3d ray, List<int> hitTriangles = null, double fMaxDist = double.MaxValue, bool handleCoplanarRays = false)
         {
             if (mesh_timestamp != mesh.ShapeTimestamp)
                 throw new Exception("NTMeshAABBTree3.FindNearestHitTriangle: mesh has been modified since tree construction");
@@ -416,11 +416,11 @@ namespace g4
             //   to fNearestT, and box hit returns double.MaxValue on no-hit. So, if we set
             //   nearestT to double.MaxValue, then we will test all boxes (!)
             double fUseMaxDist = (fMaxDist < double.MaxValue) ? fMaxDist : float.MaxValue;
-            int nCount = find_all_hit_triangles(root_index, hitTriangles, ref ray, fUseMaxDist);
+            int nCount = find_all_hit_triangles(root_index, hitTriangles, ref ray, fUseMaxDist, handleCoplanarRays);
             return nCount;
         }
 
-        protected int find_all_hit_triangles(int iBox, List<int> hitTriangles, ref Ray3d ray, double fMaxDist)
+        protected int find_all_hit_triangles(int iBox, List<int> hitTriangles, ref Ray3d ray, double fMaxDist, bool handleCoplanarRays = false)
         {
             int hit_count = 0;
 
@@ -437,7 +437,7 @@ namespace g4
 
                     mesh.GetTriVertices(ti, ref tri.V0, ref tri.V1, ref tri.V2);
                     double rayt;
-                    if (IntrRay3Triangle3.Intersects(ref ray, ref tri.V0, ref tri.V1, ref tri.V2, out rayt))
+                    if (IntrRay3Triangle3.Intersects(ref ray, ref tri.V0, ref tri.V1, ref tri.V2, out rayt, handleCoplanarRays))
                     {
                         if (rayt < fMaxDist)
                         {
@@ -467,7 +467,7 @@ namespace g4
                     iChild1 = (-iChild1) - 1;
                     double fChild1T = box_ray_intersect_t(iChild1, ray);
                     if (fChild1T <= fMaxDist + e)
-                        hit_count += find_all_hit_triangles(iChild1, hitTriangles, ref ray, fMaxDist);
+                        hit_count += find_all_hit_triangles(iChild1, hitTriangles, ref ray, fMaxDist, handleCoplanarRays);
 
                 }
                 else
@@ -477,11 +477,11 @@ namespace g4
 
                     double fChild1T = box_ray_intersect_t(iChild1, ray);
                     if (fChild1T <= fMaxDist + e)
-                        hit_count += find_all_hit_triangles(iChild1, hitTriangles, ref ray, fMaxDist);
+                        hit_count += find_all_hit_triangles(iChild1, hitTriangles, ref ray, fMaxDist, handleCoplanarRays);
 
                     double fChild2T = box_ray_intersect_t(iChild2, ray);
                     if (fChild2T <= fMaxDist + e)
-                        hit_count += find_all_hit_triangles(iChild2, hitTriangles, ref ray, fMaxDist);
+                        hit_count += find_all_hit_triangles(iChild2, hitTriangles, ref ray, fMaxDist, handleCoplanarRays);
                 }
             }
 

--- a/spatial/SpatialInterfaces.cs
+++ b/spatial/SpatialInterfaces.cs
@@ -18,7 +18,7 @@ namespace g4
         /// <summary>
         /// Find id of triangle intersected by ray, where intersection point is within distance fMaxDist, or return DMesh3.InvalidID if not found
         /// </summary>
-        int FindNearestHitTriangle(Ray3d ray, double fMaxDist = double.MaxValue);
+        int FindNearestHitTriangle(Ray3d ray, double fMaxDist = double.MaxValue, bool handleCoplanarRays = false);
 
         bool SupportsPointContainment { get; }
 


### PR DESCRIPTION
- Changing the visibility of **NTMesh3** internal data structures (`vertices`, `normals`, `colors`, and `triangles`) to `protected`.
- Introducing other methods for the manipulation of classes derived from **NTMesh3**: `CopyByReference()` and `RebuildIndexingStructures()`.
- Implementing a method to compute the **NTMesh3** vertices' normals.
- Adding the option to handle coplanar ray-triangle intersection.
- Implementing a beam tracing method in **NTMeshAABBTree**.
- Adding tests to **NTMeshAABBTree**.